### PR TITLE
Make disclaimer translatable

### DIFF
--- a/wp-content/plugins/separate-disclaimer/wpml-config.xml
+++ b/wp-content/plugins/separate-disclaimer/wpml-config.xml
@@ -1,0 +1,5 @@
+<wpml-config>
+	<custom-types>
+		<custom-type translate="1">disclaimer</custom-type>
+	</custom-types>
+</wpml-config>


### PR DESCRIPTION
Add wpml-config.xml

Note: The translatability is only activated after visiting the WPML translation options once so far.