### PR TITLE
Check public key for live websites

### DIFF
--- a/wp-content/plugins/wp-api-extensions/endpoints/RestApi_Multisites.php
+++ b/wp-content/plugins/wp-api-extensions/endpoints/RestApi_Multisites.php
@@ -20,8 +20,6 @@ class RestApi_Multisites extends RestApi_ExtensionBase {
 
 	public function get_multisites() {
 		$multisites = wp_get_sites();
-		$this->load_included_site_ids();
-
 		$result = [];
 		foreach ($multisites as $blog) {
 			$result[] = $this->prepare_item($blog);
@@ -41,45 +39,10 @@ class RestApi_Multisites extends RestApi_ExtensionBase {
 			'color' => '#FFA000',
 			'path' => $blog['path'],
 			'description' => get_bloginfo($blog),
-			'live' => in_array($id, $this->included_site_ids)
+			'live' => $blog['public']
 		];
 		restore_current_blog();
 		return $result;
-	}
-
-	private function get_live_instances() {
-		$filepath = __DIR__ . '/' . self::LIVEINSTANCES_FILENAME;
-		$handle = fopen($filepath, "r");
-		if (!$handle) {
-			throw new RuntimeException("Could not open live instances file '" . $filepath . "'");
-		}
-		try {
-			$ids = [];
-			while (($line = fgets($handle)) !== false) {
-				$id_length = strpos($line, " ");
-				if ($id_length > 0) {
-					$id = substr($line, 0, $id_length);
-				} else {
-					$id = $line;
-				}
-				$ids[] = $id;
-			}
-		} finally {
-			fclose($handle);
-		}
-		return $ids;
-	}
-
-	/**
-	 * If the included site ids are not already loaded,
-	 * retrieves them and stores them in #included_site_ids.
-	 */
-	private function load_included_site_ids() {
-		if ($this->included_site_ids !== false) {
-			// already loaded
-			return;
-		}
-		$this->included_site_ids = $this->get_live_instances();
 	}
 }
 

--- a/wp-content/plugins/wp-api-extensions/endpoints/RestApi_Multisites.php
+++ b/wp-content/plugins/wp-api-extensions/endpoints/RestApi_Multisites.php
@@ -20,7 +20,7 @@ class RestApi_Multisites extends RestApi_ExtensionBase {
 
 	public function get_multisites() {
 		$multisites = wp_get_sites();
-		
+
 		$result = [];
 		foreach ($multisites as $blog) {
 			$result[] = $this->prepare_item($blog);

--- a/wp-content/plugins/wp-api-extensions/endpoints/RestApi_Multisites.php
+++ b/wp-content/plugins/wp-api-extensions/endpoints/RestApi_Multisites.php
@@ -20,6 +20,7 @@ class RestApi_Multisites extends RestApi_ExtensionBase {
 
 	public function get_multisites() {
 		$multisites = wp_get_sites();
+		
 		$result = [];
 		foreach ($multisites as $blog) {
 			$result[] = $this->prepare_item($blog);


### PR DESCRIPTION
Replace flag "live" with wordpress standard.

If a website is marked as public by admin,  live parameter would be true.