### PR TITLE
WP API formatting

### DIFF
--- a/wp-content/plugins/ig-mobile-preview/css/mobile-preview.css
+++ b/wp-content/plugins/ig-mobile-preview/css/mobile-preview.css
@@ -31,7 +31,7 @@
 
     padding-left: 10px;
     padding-right: 20px; /* hide the scrollbar */
-    width: 375px;
+    width: 355px;
     height: 519px;
 
     margin-left: 15px;
@@ -40,3 +40,5 @@
     overflow-y: scroll;
     overflow-wrap: break-word;
 }
+
+#mobile-preview-content > p {  margin-top: 0em;  margin-bottom: 0.8em; }

--- a/wp-content/plugins/ig-mobile-preview/js/copy-content.js
+++ b/wp-content/plugins/ig-mobile-preview/js/copy-content.js
@@ -17,7 +17,9 @@
 		var editorContent = mobilePreview.postContent.text();
 		// replace all \n with surrounding p tags
 		// split-join is faster than replace: http://jsperf.com/replace-all-vs-split-join
-		editorContent = "<p>" + editorContent.split("\n").join("</p><p>") + "</p>";
+		//editorContent = "<p>" + editorContent.split("\n").join("</p><p>") + "</p>";
+		//editorContent = editorContent.split("\n").join("<br>");
+		editorContent = editorContent.replace("\n","<br>");
 		mobilePreview.content.html(editorContent);
 	};
 }(window.mobilePreview = window.mobilePreview || {}, jQuery));

--- a/wp-content/plugins/ig-mobile-preview/js/copy-content.js
+++ b/wp-content/plugins/ig-mobile-preview/js/copy-content.js
@@ -17,8 +17,6 @@
 		var editorContent = mobilePreview.postContent.text();
 		// replace all \n with surrounding p tags
 		// split-join is faster than replace: http://jsperf.com/replace-all-vs-split-join
-		//editorContent = "<p>" + editorContent.split("\n").join("</p><p>") + "</p>";
-		//editorContent = editorContent.split("\n").join("<br>");
 		editorContent = editorContent.replace("\n","<br>");
 		mobilePreview.content.html(editorContent);
 	};

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
@@ -206,15 +206,18 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBaseV0 {
 
 	protected function prepare_content($post) {
 		$content = $post->post_content;
-		$match_result = preg_match(self::EMPTY_P_PATTERN, $content);
-		if ($match_result === false) {
-			throw new RuntimeException("preg_match on content indicated error status (pattern='" . self::EMPTY_P_PATTERN . "', content='$content')");
-		}
-		if ($match_result) {
-			return self::EMPTY_CONTENT;
-		}
-		// replace all newlines with surrounding p tags
-		return "<p>" . str_replace(["\r\n", "\r", "\n"], "</p><p>", $content) . "</p>";
+/*
+ *		$match_result = preg_match(self::EMPTY_P_PATTERN, $content);
+ *		if ($match_result === false) {
+ *			throw new RuntimeException("preg_match on content indicated error status (pattern='" . self::EMPTY_P_PATTERN . "', content='$content')");
+ *		}
+ *		if ($match_result) {
+ *			return self::EMPTY_CONTENT;
+ *		}
+ *		// replace all newlines with surrounding p tags
+ *		return "<p>" . str_replace(["\r\n", "\r", "\n"], "</p><p>", $content) . "</p>";
+ */
+		return str_replace(["\r\n", "\r", "\n"], "<br>", $content);
 	}
 
 	protected function prepare_excerpt($post) {

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
@@ -206,17 +206,6 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBaseV0 {
 
 	protected function prepare_content($post) {
 		$content = $post->post_content;
-/*
- *		$match_result = preg_match(self::EMPTY_P_PATTERN, $content);
- *		if ($match_result === false) {
- *			throw new RuntimeException("preg_match on content indicated error status (pattern='" . self::EMPTY_P_PATTERN . "', content='$content')");
- *		}
- *		if ($match_result) {
- *			return self::EMPTY_CONTENT;
- *		}
- *		// replace all newlines with surrounding p tags
- *		return "<p>" . str_replace(["\r\n", "\r", "\n"], "</p><p>", $content) . "</p>";
- */
 		return str_replace(["\r\n", "\r", "\n"], "<br>", $content);
 	}
 


### PR DESCRIPTION
Currently the API is stripping p-tags with its styles. This behaviour removes LTR and LTR attributes which are needed when working with arabic texts.

This pull request together with https://github.com/Integreat/app-android/pull/195 leaves p-tags in and only replaces \\n with \<br\>.

For better viewing, a paragraph spacing of 0.8em is inserted.