### PR TITLE
Re-add line to mark revisionary pages as pending in tree-page-view

### DIFF
--- a/wp-content/plugins/cms-tree-page-view/functions.php
+++ b/wp-content/plugins/cms-tree-page-view/functions.php
@@ -1503,7 +1503,7 @@ function cms_tpv_print_childs($pageID, $view = "all", $arrOpenChilds = null, $po
 					"id": "cms-tpv-<?php echo $onePage->ID ?>",
 					"post_id": "<?php echo $onePage->ID ?>",
 					"post_type": "<?php echo $onePage->post_type ?>",
-					"post_status": "<?php echo $onePage->post_status ?>",
+                    "post_status": "<?php echo page_has_pending_revision($onePage->ID) ? 'pending' : $onePage->post_status ?>",
 					"post_status_translated": "<?php echo isset($post_statuses[$onePage->post_status]) ? $post_statuses[$onePage->post_status] : $onePage->post_status  ?>",
 					"rel": "<?php echo $rel ?>",
 					"childCount": <?php echo ( !empty( $arrChildPages ) ) ? sizeof( $arrChildPages ) : 0 ; ?>,


### PR DESCRIPTION
I forgot this in #436.
Will be unnecessary in the future with #446 