### PR TITLE
Fix TinyMCE CSS error message (workaround)

### DIFF
--- a/wp-includes/class-wp-editor.php
+++ b/wp-includes/class-wp-editor.php
@@ -986,8 +986,8 @@ final class _WP_Editors {
 		$version = 'ver=' . get_bloginfo( 'version' );
 
 		// Default stylesheets
-		$settings['content_css'] = includes_url( "css/dashicons$suffix.css?$version" ) . ',' .
-			includes_url( "js/tinymce/skins/wordpress/wp-content.css?$version" );
+		//$settings['content_css'] = includes_url( "css/dashicons$suffix.css?$version" ) . ',' .
+		//	includes_url( "js/tinymce/skins/wordpress/wp-content.css?$version" );
 
 		return $settings;
 	}


### PR DESCRIPTION
Hotfix / Workaround for `Failed to load content css: https://cms.integreat-app.de/augsburg/wp-includes/js/tinymce/skins/wp-content.css?ver=4.8.3` error message. The CSS file does not seem to be important. Hopefully it works with the next version.