### PR TITLE
Feature/recurring events

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedEvents.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedEvents.php
@@ -31,9 +31,9 @@ class RestApi_ModifiedEventsV0 extends RestApi_ModifiedContentV0 {
 			GROUP_CONCAT(CONCAT(terms.term_id, ':', terms.name)) AS terms";
 	}
 
-	protected function build_query_from($initial_event_id = null) {
+	protected function build_query_from($initial_event = null) {
 		global $wpdb;
-		return parent::build_query_from($initial_event_id) . "
+		return parent::build_query_from($initial_event) . "
 			JOIN {$wpdb->prefix}em_events em_events
 					ON em_events.post_id = posts.ID
 			LEFT JOIN {$wpdb->prefix}em_locations em_locations

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedEvents.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedEvents.php
@@ -31,9 +31,9 @@ class RestApi_ModifiedEventsV0 extends RestApi_ModifiedContentV0 {
 			GROUP_CONCAT(CONCAT(terms.term_id, ':', terms.name)) AS terms";
 	}
 
-	protected function build_query_from() {
+	protected function build_query_from($initial_event_id = null) {
 		global $wpdb;
-		return parent::build_query_from() . "
+		return parent::build_query_from($initial_event_id) . "
 			JOIN {$wpdb->prefix}em_events em_events
 					ON em_events.post_id = posts.ID
 			LEFT JOIN {$wpdb->prefix}em_locations em_locations
@@ -43,7 +43,6 @@ class RestApi_ModifiedEventsV0 extends RestApi_ModifiedContentV0 {
 			LEFT JOIN {$wpdb->prefix}terms terms
 					ON terms.term_id = term_relationships.term_taxonomy_id";
 	}
-
 
 	protected function build_query_groups() {
 		$groups = parent::build_query_groups();


### PR DESCRIPTION
This changes the API query for events. When fetching events, the following 3 steps get performed:

1. select all normal (non-recurring) events
2. select all initial events (the first dates of each recurring event) with the `post_type` 'event-recurring'
3. select the corresponding recurring events for every initial event and use the translation of its initial event (the recurring events don't have entries in the translations table - even when translations are enabled for recurring events)

In the end, all event arrays get merged and returned.

**Recurring events will only show up in the API-results, if translations are enabled for recurring events (they are disabled by default). You can find this setting when creating or editing a recurring event and scrolling to the bottom of the page).**