### PR TITLE
add extras to api v0

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_Extras.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_Extras.php
@@ -1,0 +1,45 @@
+<?php
+
+require_once __DIR__ . '/RestApi_ExtensionBase.php';
+
+class RestApi_ExtrasV0 extends RestApi_ExtensionBaseV0 {
+
+	const URL = 'extras';
+
+	public function __construct() {
+	}
+
+	public function register_routes($namespace) {
+		parent::register_route($namespace, self::URL, '/', [
+			'callback' => [
+				$this,
+				'get_extras'
+			]
+		]);
+	}
+
+	public function get_extras() {
+		global $wpdb;
+		$query_str = "SELECT * FROM $wpdb->options WHERE option_name LIKE 'ige-%'";
+		$query_results = $wpdb->get_results($query_str, OBJECT);
+		$result = [];
+		foreach ($query_results as $extra) {
+			$result[] = $this->prepare_item($extra);
+		}
+		return $result;
+	}
+
+	protected function prepare_item($extra){
+		$extra_prepared = [
+			'alias' => $extra->option_name
+		];
+		$extra_value = json_decode($extra->option_value, true);
+		if (is_array($extra_value)) {
+			$extra_prepared = array_merge($extra_prepared, $extra_value);
+		} else {
+			$extra_prepared['enabled'] = 0;
+		}
+		return $extra_prepared;
+	}
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/plugin.php
+++ b/wp-content/plugins/ig-wp-api-extensions/plugin.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/endpoints/v0/RestApi_WpmlLanguages.php';
 require_once __DIR__ . '/endpoints/v0/RestApi_ModifiedPages.php';
 require_once __DIR__ . '/endpoints/v0/RestApi_ModifiedEvents.php';
 require_once __DIR__ . '/endpoints/v0/RestApi_ModifiedDisclaimer.php';
+require_once __DIR__ . '/endpoints/v0/RestApi_Extras.php';
 // v1
 require_once __DIR__ . '/endpoints/RestApi_Multisites.php';
 
@@ -26,6 +27,7 @@ const ENDPOINT_LANGUAGES = 'languages';
 const ENDPOINT_PAGES = 'pages';
 const ENDPOINT_EVENTS = 'events';
 const ENDPOINT_DISCLAIMER = 'disclaimer';
+const ENDPOINT_EXTRAS = 'extras';
 
 add_action('rest_api_init', function () {
 	/**
@@ -39,6 +41,7 @@ add_action('rest_api_init', function () {
 			ENDPOINT_PAGES => new RestApi_ModifiedPagesV0(),
 			ENDPOINT_EVENTS => new RestApi_ModifiedEventsV0(),
 			ENDPOINT_DISCLAIMER => new RestApi_ModifiedDisclaimerV0(),
+			ENDPOINT_EXTRAS => new RestApi_ExtrasV0(),
 		],
 		CURRENT_VERSION => [
 			ENDPOINT_MULTISITES => new RestApi_Multisites(),


### PR DESCRIPTION
this adds the new api v0 endpoint "extras". due to the database structure, the response format is not handled by the api, but in the backend instead (the api response includes the value field of every extra in the settings page). it depends on consistent and correct json-formatting in the backend. proposed format:
```
{
    "name": [string],
    "type": [string],
    "enabled": [boolean],
    "extension": {
        "url": [string]
    }
}
```
once the extra-settings are adapted, this should fix #619.