### PR TITLE
[ig-mpdf] improvements (fixes #692)

### DIFF
--- a/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
@@ -48,28 +48,37 @@ class IntegreatMpdfAPI {
 			if ($id === null) {
 				$id = url_to_postid($url);
 			}
-			$children_ids = new WP_Query([
-				'post_type' => 'page',
-				'post_status' => 'publish',
-				'post_parent' => $id,
-				'orderby' => 'menu_order post_title',
-				'order' => 'ASC',
-				'posts_per_page' => -1,
-				'fields' => 'ids',
-			]);
-			$page_ids = array_merge([$id], $children_ids->posts);
+			$page_ids = $this->get_children($id);
 		} else {
-			$page_ids = (new WP_Query([
-				'post_type' => 'page',
-				'post_status' => 'publish',
-				'orderby' => 'menu_order post_title',
-				'order'   => 'ASC',
-				'posts_per_page' => -1,
-				'fields' => 'ids',
-			]))->posts;
+			$page_ids = array_slice($this->get_children(0), 0);
 		}
 		$pdf = new IntegreatMpdf($page_ids);
 		return $pdf->get_pdf();
+	}
+
+	/**
+	 * Get all page ids of the given page and all its children in the correct order
+	 *
+	 * @param $id int|string
+	 * @return array of page id and all its children's ids
+	 */
+	private function get_children($id) {
+		$direct_children = (new WP_Query([
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_parent' => $id,
+			'orderby' => 'menu_order post_title',
+			'order' => 'ASC',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		]))->posts;
+		if (empty($direct_children)) {
+			return [$id];
+		} else {
+			return array_reduce(array_map([$this, 'get_children'], $direct_children), function ($all_children, $grand_children) {
+				return array_merge($all_children, $grand_children);
+			}, [$id]);
+		}
 	}
 
 }

--- a/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
@@ -18,15 +18,13 @@ class IntegreatMpdfAPI {
 					'id' => [
 						'required' => false,
 						'validate_callback' => function($id) {
-							$page = get_post($id);
-							return $page !== null && $page->post_type === 'page';
+							return $this->is_valid($id);
 						}
 					],
 					'url' => [
 						'required' => false,
 						'validate_callback' => function($url) {
-							$page = get_post(url_to_postid($url));
-							return $page !== null && $page->post_type === 'page';
+							return $this->is_valid(url_to_postid($url));
 						}
 					],
 				]
@@ -38,7 +36,7 @@ class IntegreatMpdfAPI {
 	 * Get pdf or return error if the request is not valid
 	 *
 	 * @param $request WP_REST_Request
-	 * @return mixed pdf
+	 * @return mixed
 	 * @throws \Mpdf\MpdfException
 	 */
 	public function get_pdf(WP_REST_Request $request) {
@@ -60,7 +58,7 @@ class IntegreatMpdfAPI {
 	 * Get all page ids of the given page and all its children in the correct order
 	 *
 	 * @param $id int|string
-	 * @return array of page id and all its children's ids
+	 * @return array
 	 */
 	private function get_children($id) {
 		$direct_children = (new WP_Query([
@@ -79,6 +77,17 @@ class IntegreatMpdfAPI {
 				return array_merge($all_children, $grand_children);
 			}, [$id]);
 		}
+	}
+
+	/**
+	 * Check whether a given $id is a valid page id for pdf generation
+	 *
+	 * @param $id int|string
+	 * @return bool
+	 */
+	private function is_valid($id) {
+		$page = get_post($id);
+		return $page !== null && $page->post_type === 'page' && $page->post_status === 'publish';
 	}
 
 }


### PR DESCRIPTION
- displays pages in the correct order (fixes #692)
- includes all children of a page (and not only the direct children)
- only generates pdfs of published pages