### PR TITLE
[ig-settings] change encoding of input values (fixes #694)

### DIFF
--- a/wp-content/plugins/ig-settings/classes/IntegreatExtra.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatExtra.php
@@ -15,17 +15,17 @@ class IntegreatExtra {
 	public $url;
 	public $post;
 	public $thumbnail;
-	public static $current_extra = false;
+	public static $current_extra = [];
 	public static $current_error = [];
 
 	public function __construct($extra = []) {
 		$extra = (object) $extra;
 		$this->id = isset($extra->id) ? (int) $extra->id : null;
-		$this->name = isset($extra->name) && $extra->name !== ''  ? htmlspecialchars($extra->name) : null;
-		$this->alias = isset($extra->alias) && $extra->alias !== ''  ? htmlspecialchars($extra->alias) : null;
-		$this->url = isset($extra->url) && $extra->url !== ''  ? htmlspecialchars($extra->url) : null;
-		$this->post = isset($extra->post) && $extra->post !== '' ? str_replace('&qout;', '"', $extra->post) : null;
-		$this->thumbnail = isset($extra->thumbnail) && $extra->thumbnail !== '' ? htmlspecialchars($extra->thumbnail) : null;
+		$this->name = isset($extra->name) && $extra->name !== ''  ? $extra->name : null;
+		$this->alias = isset($extra->alias) && $extra->alias !== ''  ? $extra->alias : null;
+		$this->url = isset($extra->url) && $extra->url !== ''  ? $extra->url : null;
+		$this->post = isset($extra->post) && $extra->post !== '' ? $extra->post : null;
+		$this->thumbnail = isset($extra->thumbnail) && $extra->thumbnail !== '' ? $extra->thumbnail : null;
 	}
 
 	public function validate() {
@@ -63,14 +63,14 @@ class IntegreatExtra {
 		} elseif (filter_var($this->url, FILTER_VALIDATE_URL) === false) {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
-				'message' => 'The given URL "' . $this->url . '" is not valid'
+				'message' => 'The given URL "' . htmlspecialchars($this->url) . '" is not valid'
 			];
 			self::$current_error[] = 'url';
 		}
 		if ($this->post && !json_decode($this->post)) {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
-				'message' => 'The post-values "' . $this->post . '" are no valid json'
+				'message' => 'The post-values "' . htmlspecialchars($this->post) . '" are no valid json'
 			];
 			self::$current_error[] = 'post';
 		}
@@ -83,7 +83,7 @@ class IntegreatExtra {
 		} elseif (filter_var($this->thumbnail, FILTER_VALIDATE_URL) === false) {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
-				'message' => 'The given thumbnail-URL "' . $this->thumbnail . '" is not valid'
+				'message' => 'The given thumbnail-URL "' . htmlspecialchars($this->thumbnail) . '" is not valid'
 			];
 			self::$current_error[] = 'thumbnail';
 		}
@@ -224,40 +224,41 @@ class IntegreatExtra {
 		}
 		$select_form .= '<select name="id">';
 		foreach(self::get_extras() as $extra) {
-			$select_form .= '<option value="' . $extra->id . '" ' . (isset($_GET['id']) && $_GET['id'] === $extra->id ? 'selected' : '') . '>' . $extra->name . '</option>';
+			$select_form .= '<option value="' . $extra->id . '" ' . (isset($_GET['id']) && $_GET['id'] === $extra->id ? 'selected' : '') . '>' . htmlspecialchars($extra->name) . '</option>';
 		}
 		$select_form .= '</select><input class="button" type="submit" name="submit" value=" Edit "></form><br>';
 		return $select_form;
 	}
 
 	private static function get_extra_form() {
-		$extra = self::$current_extra;
+		$extra = IntegreatSettingsPlugin::encode_quotes_deep(self::$current_extra);
+		$extra_post = IntegreatSettingsPlugin::encode_quotes_deep(stripslashes_deep($_POST['extra']));
 		$extra_form = '
 			<form action="' . $_SERVER['REQUEST_URI'] . '" method="post">
 				<input type="hidden" name="extra[id]" value="' . ($extra ? $extra->id : '') . '">
 				<div>
 					<label for="extra[name]">Name <b>*</b></label>
-					<input type="text" class="' . ( !empty(self::$current_error) ? (in_array('name', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[name]" value="' . ($extra ? (in_array('name', self::$current_error) ? htmlspecialchars($_POST['extra']['name']) : $extra->name) : '') . '">
+					<input type="text" class="' . (!empty(self::$current_error) ? (in_array('name', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[name]" value="' . ($extra ? (in_array('name', self::$current_error) ? $extra_post->name : $extra->name) : '') . '">
 				</div>
 				<br>
 				<div>
 					<label for="extra[alias]">Alias <b>*</b></label>
-					<input type="text" class="' . ( !empty(self::$current_error) ? (in_array('alias', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[alias]" value="' . ($extra ? (in_array('alias', self::$current_error) ? htmlspecialchars($_POST['extra']['alias']) : $extra->alias) : '') . '">
+					<input type="text" class="' . (!empty(self::$current_error) ? (in_array('alias', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[alias]" value="' . ($extra ? (in_array('alias', self::$current_error) ? $extra_post->alias : $extra->alias) : '') . '">
 				</div>
 				<br>
 				<div>
 					<label for="extra[url]">URL <b>*</b></label>
-					<input type="text" class="' . ( !empty(self::$current_error) ? (in_array('url', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[url]" value="' . ($extra ? (in_array('url', self::$current_error) ? htmlspecialchars($_POST['extra']['url']) : $extra->url) : '') . '">
+					<input type="text" class="' . (!empty(self::$current_error) ? (in_array('url', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[url]" value="' . ($extra ? (in_array('url', self::$current_error) ? $extra_post->url : $extra->url) : '') . '">
 				</div>
 				<br>
 				<div>
 					<label for="extra[post]">Post-Values for URL</label>
-					<input type="text" class="' . ( !empty(self::$current_error) ? (in_array('post', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[post]" value="' . ($extra ? str_replace('"', '&quot;', (in_array('post', self::$current_error) ? stripcslashes($_POST['extra']['post']) : $extra->post)) : '') . '">
+					<input type="text" class="' . (!empty(self::$current_error) ? (in_array('post', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[post]" value="' . ($extra ? (in_array('post', self::$current_error) ? $extra_post->post : $extra->post) : '') . '">
 				</div>
 				<br>
 				<div>
 					<label for="extra[thumbnail]">Thumbnail-URL <b>*</b></label>
-					<input type="text" class="' . ( !empty(self::$current_error) ? (in_array('thumbnail', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[thumbnail]" value="' . ($extra ? (in_array('thumbnail', self::$current_error) ? htmlspecialchars($_POST['extra']['thumbnail']) : $extra->thumbnail) : '') . '">
+					<input type="text" class="' . (!empty(self::$current_error) ? (in_array('thumbnail', self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="extra[thumbnail]" value="' . ($extra ? (in_array('thumbnail', self::$current_error) ? $extra_post->thumbnail : $extra->thumbnail) : '') . '">
 				</div>
 				<br>
 				<input class="button button-primary" type="submit" name="submit" value=" Save ">
@@ -303,7 +304,7 @@ class IntegreatExtra {
 			];
 			return false;
 		}
-		$extra = new IntegreatExtra(stripslashes_deep($_POST['extra']));
+		$extra = new IntegreatExtra(IntegreatSettingsPlugin::decode_quotes_deep(stripslashes_deep($_POST['extra'])));
 		self::$current_extra = $extra;
 		if ($_POST['submit'] == ' Delete ') {
 			$deleted = $extra->delete();
@@ -318,7 +319,7 @@ class IntegreatExtra {
 				'type' => 'success',
 				'message' => 'Extra successfully deleted'
 			];
-			self::$current_extra = false;
+			self::$current_extra = [];
 			return true;
 		}
 		if (!$extra->validate()) {
@@ -343,7 +344,7 @@ class IntegreatExtra {
 			'type' => 'success',
 			'message' => 'Extra saved successfully'
 		];
-		self::$current_extra = false;
+		self::$current_extra = [];
 		return true;
 	}
 

--- a/wp-content/plugins/ig-settings/classes/IntegreatExtraConfig.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatExtraConfig.php
@@ -58,7 +58,7 @@ class IntegreatExtraConfig {
 		if ($this->enabled && (strpos($extra->url, '{plz}') !== false || strpos($extra->post, '{plz}') !== false) && !$plz){
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
-				'message' => 'The extra "' . $extra->name . '" can not be enabled because it depends on the setting "plz" for this location'
+				'message' => 'The extra "' . htmlspecialchars($extra->name) . '" can not be enabled because it depends on the setting "plz" for this location'
 			];
 			self::$current_error[] = 'enabled';
 			return false;
@@ -172,7 +172,7 @@ class IntegreatExtraConfig {
 			}
 			$form .= '
 				<div>
-					<label for="' . $extra->id . '">' . $extra->name . '</label>
+					<label for="' . $extra->id . '">' . htmlspecialchars($extra->name) . '</label>
 					<label class="switch">
 						<input type="checkbox" name="' . $extra->id . '"' . ($extra_config->enabled ? ' checked' : '') . '>
 						<span class="slider round"></span>
@@ -210,7 +210,7 @@ class IntegreatExtraConfig {
 				if ($saved === false) {
 					IntegreatSettingsPlugin::$admin_notices[] = [
 						'type' => 'error',
-						'message' => 'Extra "' . IntegreatExtra::get_extra_by_id($extra_config->extra_id)->name . '" could not be ' . ($extra_config->enabled ? 'enabled' : 'disabled')
+						'message' => 'Extra "' . htmlspecialchars(IntegreatExtra::get_extra_by_id($extra_config->extra_id)->name) . '" could not be ' . ($extra_config->enabled ? 'enabled' : 'disabled')
 					];
 					$error_occurred = true;
 					continue;

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
@@ -22,7 +22,7 @@ class IntegreatSettingConfig {
 		$setting_config = (object) $setting_config;
 		$this->id = isset($setting_config->id) ? (int) $setting_config->id : null;
 		$this->setting_id = isset($setting_config->setting_id) ? (int) $setting_config->setting_id : null;
-		$this->value = (isset($setting_config->value) && $setting_config->value !== '' ? htmlspecialchars($setting_config->value) : null);
+		$this->value = (isset($setting_config->value) && $setting_config->value !== '' ? $setting_config->value : null);
 	}
 
 	public function validate() {
@@ -57,7 +57,7 @@ class IntegreatSettingConfig {
 		if ($setting->type === 'bool' && !in_array($this->value, ['0', '1'])) {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
-				'message' => 'The value "' . $this->value . '" is not boolean'
+				'message' => 'The value "' . htmlspecialchars($this->value) . '" is not boolean'
 			];
 			self::$current_error[] = $setting->alias;
 			return false;
@@ -78,7 +78,7 @@ class IntegreatSettingConfig {
 								if ($extra_config->validate() && $extra_config->save()) {
 									IntegreatSettingsPlugin::$admin_notices[] = [
 										'type' => 'info',
-										'message' => 'The extra "' . $extra->name . '" was disabled because it depends on the setting "plz" for this location'
+										'message' => 'The extra "' . htmlspecialchars($extra->name) . '" was disabled because it depends on the setting "plz" for this location'
 									];
 								}
 							}
@@ -88,7 +88,7 @@ class IntegreatSettingConfig {
 			} elseif (!ctype_digit($this->value) || strlen($this->value) !== 5) {
 				IntegreatSettingsPlugin::$admin_notices[] = [
 					'type' => 'error',
-					'message' => 'The PLZ "' . $this->value . '" is not valid'
+					'message' => 'The PLZ "' . htmlspecialchars($this->value) . '" is not valid'
 				];
 				self::$current_error[] = $setting->alias;
 				return false;
@@ -273,8 +273,8 @@ class IntegreatSettingConfig {
 			if ($setting->type === 'string') {
 				$form .= '
 					<div>
-						<label for="' . $setting->id . '">' . $setting->name . '</label>
-						<input type="text" class="' . ( !empty(self::$current_error) ? ( in_array($setting->alias, self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="' . $setting->id . '" value="' . (in_array($setting->alias, self::$current_error) ? htmlspecialchars($_POST[$setting->id]) : $setting_config->value) . '">
+						<label for="' . $setting->id . '">' . htmlspecialchars($setting->name) . '</label>
+						<input type="text" class="' . (!empty(self::$current_error) ? (in_array($setting->alias, self::$current_error) ? 'ig-error' : 'ig-success') : '') . '" name="' . $setting->id . '" value="' . str_replace('"', '&quot;', (in_array($setting->alias, self::$current_error) ? stripslashes($_POST[$setting->id]) : $setting_config->value)) . '">
 					</div>
 					<br>
 				';
@@ -283,7 +283,7 @@ class IntegreatSettingConfig {
 				$hidden = (!$current_blog->public OR $current_blog->spam OR $current_blog->deleted OR $current_blog->archived OR $current_blog->mature);
 				$form .= '
 					<div>
-						<label for="' . $setting->id . '">' . $setting->name . '</label>
+						<label for="' . $setting->id . '">' . htmlspecialchars($setting->name) . '</label>
 						<label class="switch">
 							<input type="checkbox" name="' . $setting->id . '"' . (($setting->alias === 'hidden' && $hidden) || ($setting->alias !== 'hidden' && $setting_config->value === '1') ? ' checked' : '') . '>
 							<span class="slider round"></span>
@@ -318,7 +318,7 @@ class IntegreatSettingConfig {
 					}
 				} elseif ($setting->type === 'string') {
 					if (isset($_POST[$setting_config->setting_id])) {
-						$setting_config->value = $_POST[$setting_config->setting_id];
+						$setting_config->value = str_replace('&quot;', '"', stripslashes($_POST[$setting_config->setting_id]));
 					} else {
 						IntegreatSettingsPlugin::$admin_notices[] = [
 							'type' => 'error',
@@ -336,7 +336,7 @@ class IntegreatSettingConfig {
 				if ($saved === false) {
 					IntegreatSettingsPlugin::$admin_notices[] = [
 						'type' => 'error',
-						'message' => 'Setting "' . $setting->name . '" could not be saved'
+						'message' => 'Setting "' . htmlspecialchars($setting->name) . '" could not be saved'
 					];
 					$error_occurred = true;
 					continue;

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -281,4 +281,30 @@ class IntegreatSettingsPlugin {
 		}, 10, 1);
 	}
 
+	public static function encode_quotes_deep($object) {
+		return self::code_quotes_deep($object, true);
+	}
+
+	public static function decode_quotes_deep($object) {
+		return self::code_quotes_deep($object, false);
+	}
+
+	private static function code_quotes_deep($object, $encode) {
+		if ($object === []) {
+			return [];
+		} else {
+			return (object) array_map(function ($attribute) use ($encode) {
+				if (is_string($attribute)) {
+					if ($encode) {
+						return str_replace('"', '&quot;', $attribute);
+					} else {
+						return str_replace('&quot;', '"', $attribute);
+					}
+				} else {
+					return $attribute;
+				}
+			}, (array)$object);
+		}
+	}
+
 }


### PR DESCRIPTION
At the moment, all input strings are encoded with `htmlspecialchars()` before storing input in the database to prevent XSS. This resulted in #694 and I solved it by storing the input in the database unescaped and escape it before printing.