### PR TITLE
refactor ig-mpdf and add table of contents

### DIFF
--- a/wp-content/plugins/ig-mpdf/IntegreatMpdf.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdf.php
@@ -110,11 +110,38 @@ class IntegreatMpdf {
 				case 'fr':
 					$toc_title = 'Contenu';
 					break;
+				case 'es':
+					$toc_title = 'Contenido';
+					break;
+				case 'ku':
+					$toc_title = 'Naveroka';
+					break;
+				case 'tr':
+					$toc_title = 'Içindekiler';
+					break;
+				case 'po':
+					$toc_title = 'Treść';
+					break;
+				case 'ro':
+					$toc_title = 'Conținut';
+					break;
+				case 'ru':
+					$toc_title = 'Cодержание';
+					break;
+				case 'sr':
+					$toc_title = 'Cадржај';
+					break;
 				case 'ar':
 					$toc_title = 'محتويات';
 					break;
 				case 'fa':
 					$toc_title = 'محتویات';
+					break;
+				case 'am':
+					$toc_title = 'ይዘቶች';
+					break;
+				case 'ti':
+					$toc_title = 'ካርታ';
 					break;
 				default:
 					$toc_title = 'Table of Contents';

--- a/wp-content/plugins/ig-mpdf/IntegreatMpdf.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdf.php
@@ -1,260 +1,174 @@
 <?php
 
 use Mpdf\Mpdf;
-use Mpdf\Config\ConfigVariables;
-use Mpdf\Config\FontVariables;
 use Mpdf\MpdfException;
 
 class IntegreatMpdf {
-    private $mpdf;
-    private $config;
-    private $pages;
-    private $file_path;
+	private $mpdf;
+	private $page_ids;
+	private $language;
+	private $toc;
+	private $file_path;
+	private $file_name;
 
-    function __construct($pages) {
+	function __construct($page_ids, $toc = true) {
 		// init mpdf
 		require_once __DIR__ . '/vendor/autoload.php';
-        $this->set_pages($pages);
-        $this->file_path = 'wp-content/uploads/ig-mpdf-cache/';
-        $this->config = array(
-            'init_options' => array(
-                'margin_top' => 20,
-                'margin_left' => 20,
-                'margin_right' => 20,
-                'margin_bottom' => 26,
-                'tempDir' => dirname(__FILE__, 3) . '/uploads/ig-mpdf-cache/tmp',
-                'fontTempDir' => dirname(__FILE__, 3) . '/uploads/ig-mpdf-cache/tmp/ttfontdata',
-				'autoScriptToLang' => true,
-				'autoLangToFont' => true
-            ),
-            'file_path' => dirname(__FILE__, 4) . '/' . $this->file_path,
-        );
-
-        $this->mpdf = new Mpdf($this->config['init_options']);
-    }
+		$this->mpdf = new Mpdf([
+			'margin_top' => 20,
+			'margin_left' => 20,
+			'margin_right' => 20,
+			'margin_bottom' => 26,
+			'tempDir' => dirname(__FILE__, 3) . '/uploads/ig-mpdf-cache/tmp',
+			'fontTempDir' => dirname(__FILE__, 3) . '/uploads/ig-mpdf-cache/tmp/ttfontdata',
+			'autoScriptToLang' => true,
+			'autoLangToFont' => true
+		]);
+		$this->page_ids = $page_ids;
+		$this->toc = $toc && count($page_ids) > 1;
+		$this->language = apply_filters('wpml_current_language', null);
+		// set file path of cached file
+		$this->file_path = dirname(__FILE__, 4) . '/wp-content/uploads/ig-mpdf-cache/' . get_bloginfo('name') . '-' . $this->language . ($this->toc ? '-toc-' : '-') . md5(implode(',', $this->page_ids)) . '.pdf';
+		// get pdf title in german (if pdf consists of only one page or one category)
+		$page_title = '';
+		if (count($this->page_ids) == 1) {
+			// set title of single page if there is only one page in the pdf
+			$page_title = get_the_title(apply_filters('wpml_object_id', $this->page_ids[0], 'page', true, 'de'));
+		} else {
+			// get root pages if there is more than one page in the pdf
+			$root_page_ids = array_filter($this->page_ids, function($page_id) {
+				return get_post($page_id)->post_parent === 0;
+			});
+			// set title of root page if there is only one root page in the pdf
+			if (count($root_page_ids) == 1) {
+				$page_title = get_the_title(apply_filters('wpml_object_id', $root_page_ids[0], 'page', true, 'de'));
+			}
+		}
+		// set title to be displayed in the browser
+		$this->file_name = 'Integreat - ' . get_bloginfo('name') . ' - ' . $GLOBALS['sitepress']->get_display_language_name($this->language, 'de') . ($page_title ? ' - ' . $page_title : '');
+	}
 
 	/**
 	 * Decides whether to create a new pdf file or use a cached one
 	 *
-	 * @return mixed: link or false
 	 * @throws MpdfException
 	 */
-    public function get_pdf() {
-		if(!empty($this->pages)) {
-			$selected = $this->check_for_existing_entry();
-			if(empty($selected) or $this->modified($selected[0]->creation_date)) {
-				return $this->create_pdf();
-			} else {
-				$path = $this->config['file_path'] . $selected[0]->pdf_name . '.pdf';
-				if(file_exists($path)) {
-					return $this->get_cached_pdf($path);
-				} else {
-					return $this->create_pdf();
-				}
-			}
+	public function get_pdf() {
+		// if there is no cached pdf or the cached pdf is outdated, generate a new one
+	   	if (!file_exists($this->file_path) || !$this->is_up_to_date($this->file_path)) {
+			$this->create_pdf();
 		}
-		return false;
+		// set headers to enable pdf output to browser
+		header('Content-Type: application/pdf');
+	   	header('Content-disposition: inline; filename="' . $this->file_name . '.pdf"');
+		echo file_get_contents($this->file_path);
+		exit();
 	}
 
 	/**
 	 * Creates a new pdf file for pages
 	 *
-	 * @return string: link to file
 	 * @throws MpdfException
 	 */
-    private function create_pdf() {
-        // prepare content
-        $pages = '';
-        $ite = 0;
-        $count = count($this->pages);
-        foreach($this->pages as &$page) {
-            $post = get_post($page);
+	private function create_pdf() {
+		$this->mpdf->SetTitle($this->file_name);
+		// set rtl direction on arabic or farsi
+		if(in_array($this->language, array('ar', 'fa'))) {
+			$this->mpdf->SetDirectionality('rtl');
+		}
+		// head
+		$head = '	<html>
+						<head>
+							<style>
+								body {
+									font-family: "sans-serif";
+									font-size:   14px;
+									color:	   #000000;
+									line-height: 1.4;
+								}
+								.page {
+									margin-bottom:  35px;
+									padding-bottom: 35px;
+								}
+								.page-border {
+									border-bottom: 3px solid #BBBBBB;
+								}
+								.header_footer {
+									color: #666666;
+								}
+							</style>
+						</head>
+					<body>';
+		$this->mpdf->WriteHTML($head);
 
-            if($ite >= $count-1) {
-                $pages .= '<div class="page">';
-            } else {
-                $pages .= '<div class="page page-border">';
-            }
-            $pages .= '<h2>'.$post->post_title.'</h2>';
-            $pages .= wpautop($post->post_content);
-            $pages .= '</div>';
-            $ite++;
-        }
+		// TOC
+		if ($this->toc) {
+			switch ($this->language) {
+				case 'de':
+					$toc_title = 'Inhaltsverzeichnis';
+					break;
+				case 'fr':
+					$toc_title = 'Contenu';
+					break;
+				case 'ar':
+					$toc_title = 'محتويات';
+					break;
+				case 'fa':
+					$toc_title = 'محتویات';
+					break;
+				default:
+					$toc_title = 'Table of Contents';
+			}
+			$this->mpdf->TOCpagebreakByArray(['toc-preHTML' => '<h2>' . $toc_title . '</h2>', 'toc-odd-footer-value' => -1]);
+		}
 
-        // set rtl direction on arabic or farsi
-        if(in_array(apply_filters('wpml_current_language', null), array('ar', 'fa'))) {
-            $this->mpdf->SetDirectionality('rtl');
-        }
+		// footer
+		$footer = '	<table width="100%" style="margin-top: 20px;" class="header_footer">
+						<tr>
+							<td width="10%" valign="top" class="footer_text">{PAGENO}</td>
+							<td width="40%" valign="top" align="center">'.get_bloginfo_rss("name").'</td>
+							<td width="40%" valign="top" align="right" class="footer_text">
+								<img src="' . __DIR__ . '/logo.png" width="auto" height="25px" />
+							</td>
+						</tr>
+					</table>';
+		$this->mpdf->setHTMLFooter($footer);
 
-        // content
-        $out = '<html><head><style>
-                    body { 
-                        font-family: "sans-serif";
-                        font-size: 14px;
-                        color: #000000;
-                        line-height: 1.4;
-                    }
-                    .page {
-                        margin-bottom: 35px;
-                        padding-bottom: 35px;
-                    }
-                    .page-border {
-                        border-bottom: 3px solid #BBBBBB;
-                    }
-                    .header_footer {
-                        color: #666666;
-                    }
-                </style></head><body>';
-        $out .= $pages;
-        $out .= '</body></html>';
+		// content
+		$pages_iterator = new CachingIterator(new ArrayIterator($this->page_ids));
+		foreach($pages_iterator as $page_id) {
+			$page = get_post($page_id);
+			if ($pages_iterator->hasNext()) {
+				$this->mpdf->WriteHTML('<div class="page page-border">');
+			} else {
+				$this->mpdf->WriteHTML('<div class="page">');
+			}
+			$this->mpdf->WriteHTML('<h2>' . $page->post_title . '</h2>');
+			if ($this->toc) {
+				$this->mpdf->TOC_Entry(htmlspecialchars($page->post_title, ENT_QUOTES), count(get_post_ancestors($page)));
+			}
+			$this->mpdf->WriteHTML(wpautop($page->post_content) . '</div>');
+		}
+		$this->mpdf->WriteHTML('</body></html>');
 
-
-        // footer
-        $out_footer = '<table width="100%" style="margin-top: 20px;" class="header_footer"><tr>
-                        <td width="10%" valign="top" class="footer_text">{PAGENO}</td>
-                        <td width="40%" valign="top" align="center">'.get_bloginfo_rss("name").'</td>
-                        <td width="40%" valign="top" align="right" class="footer_text"><img 
-                        src="'. __DIR__ .'/logo.png" width="auto" height="25px" /></td>
-                        </tr></table>';
-        $this->mpdf->setHTMLFooter($out_footer);
-
-        // output
-        $this->mpdf->WriteHTML($out);
-
-        // save/cache pdf
-        $this->cache_pdf();
-
-        // open pdf
-        return $this->get_cached_pdf();
-    }
-
-    /**
-     * Cache a recently generated pdf
-	 *
-	 * @throws MpdfException
-     */
-    private function cache_pdf() {
-        global $wpdb;
-        $pdf_name = $this->create_file_name();
-
-        // check if there is a corresponding table entry
-        $selected = $this->check_for_existing_entry();
-
-        if(empty($selected)) {
-            // insert table entry
-            $data = array();
-            $data['pdf_name'] = $pdf_name;
-            $data['pages'] = $this->comma_separated_list();
-            $data['multiple'] = count($this->pages) > 1 ? 1 : 0;
-            $data['instance'] = get_bloginfo();
-
-            $wpdb->insert('wp_ig_mpdf', $data);
-        } else {
-            $wpdb->query("UPDATE wp_ig_mpdf SET creation_date=NOW() WHERE id=".$selected[0]->id);
-        }
-
-        // save file
-        $path = $this->config['file_path'] . $pdf_name . '.pdf';
-        $this->mpdf->Output($path, 'F');
-    }
+		// save/cache file
+		$this->mpdf->Output($this->file_path, 'F');
+	}
 
 	/**
-	 * Get cached pdf link
+	 * Check if the file is newer than the pages it contains
 	 *
-	 * @param string: filename
-	 * @return mixed: pdf
-	 * @throws MpdfException
+	 * @param string
+	 * @return bool
 	 */
-    private function get_cached_pdf($filename = null) {
-        if(empty($filename)) {
-			return $this->mpdf->Output();
-        } else {
-			header('Content-Type: application/pdf');
-			echo file_get_contents($filename);
-			exit();
+	private function is_up_to_date($filename) {
+		$file_modified = filemtime($filename);
+		foreach($this->page_ids as $page_id) {
+			$page_modified = get_post_modified_time('G', true, $page_id);
+			if($page_modified > $file_modified) {
+				return false;
+			}
 		}
-    }
-
-    /**
-     * Create hash depending on instance and pages
-     *
-     * @return string mixed
-     */
-    private function create_hash() {
-        $str = 'instance: ' . get_bloginfo();
-        $str .= ' pages: ';
-        foreach($this->pages as &$page) {
-            $str .= $page . ',';
-        }
-
-        return sha1($str);
-    }
-
-    /**
-     * Create file name
-     *
-     * @return string
-     */
-    private function create_file_name() {
-        $out = 'Integreat-';
-        $out .= $this->create_hash();
-        return $out;
-    }
-
-    /**
-     * Create comma separated list of pages
-     *
-     * @return string
-     */
-    private function comma_separated_list() {
-        $count = count($this->pages);
-        $out = '';
-        for($i = 0; $i < $count; $i++) {
-            $out .= $this->pages[$i];
-            if($i < $count-1) {
-                $out .= ',';
-            }
-        }
-
-        return $out;
-    }
-
-    /**
-     * Check if there exists a database table entry
-     *
-     * @return mixed: query result
-     */
-    private function check_for_existing_entry() {
-        global $wpdb;
-        return $wpdb->get_results("SELECT * FROM wp_ig_mpdf WHERE instance='" . get_bloginfo() . "' AND pages='"
-            .$this->comma_separated_list()."'");
-    }
-
-    /**
-     * Check if any of the pages has changed due to given timestamp
-     *
-     * @param string: timestamp
-     * @return bool
-     */
-    private function modified($timestamp) {
-        $date = new DateTime($timestamp);
-        foreach($this->pages as &$page) {
-            $date_page = new DateTime(get_post_modified_time('Y-m-d H:i:s', false, $page));
-            if($date_page > $date) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Set articles for export
-     *
-     * @param array pages
-     */
-    public function set_pages($pages) {
-        foreach($pages as &$page) {
-            $this->pages[] = $page;
-        }
-    }
+		return true;
+	}
 }

--- a/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
@@ -2,14 +2,14 @@
 
 class IntegreatMpdfAPI {
 
-    public function __construct() {
-        $this->custom_endpoint();
-    }
+	public function __construct() {
+		$this->custom_endpoint();
+	}
 
-    /**
-     * Add custom endpoint
-     */
-    private function custom_endpoint() {
+	/**
+	 * Add custom endpoint
+	 */
+	private function custom_endpoint() {
 		add_action('rest_api_init', function () {
 			register_rest_route( 'ig-mpdf/v1', 'pdf', [
 				'methods' => WP_REST_Server::READABLE,
@@ -30,14 +30,13 @@ class IntegreatMpdfAPI {
 				]
 			]);
 		});
-    }
+	}
 
 	/**
 	 * Get pdf or return error if the request is not valid
 	 *
 	 * @param $request WP_REST_Request
 	 * @return mixed
-	 * @throws \Mpdf\MpdfException
 	 */
 	public function get_pdf(WP_REST_Request $request) {
 		$id = $request->get_param('id');
@@ -46,12 +45,18 @@ class IntegreatMpdfAPI {
 			if ($id === null) {
 				$id = url_to_postid($url);
 			}
+			// change current language to language of given post
+			$GLOBALS['sitepress']->switch_lang(apply_filters('wpml_element_language_code', null, ['element_id' => $id, 'element_type' => 'page']), true);
 			$page_ids = $this->get_children($id);
 		} else {
 			$page_ids = array_slice($this->get_children(0), 0);
 		}
-		$pdf = new IntegreatMpdf($page_ids);
-		return $pdf->get_pdf();
+		$mpdf = new IntegreatMpdf($page_ids);
+		try {
+			$mpdf->get_pdf();
+		} catch (\Mpdf\MpdfException $e) {
+			return new WP_Error('mpdf-error', $e->getMessage(), ['status' => 500]);
+		}
 	}
 
 	/**

--- a/wp-content/plugins/ig-mpdf/IntegreatMpdfSettings.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdfSettings.php
@@ -2,188 +2,60 @@
 
 class IntegreatMpdfSettings {
 
-    private $pages;
-    private $pdf_link;
+	/**
+	 * Options page callback
+	 */
+	public static function create_admin_page() {
+		$pages = get_pages(array('sort_column' => 'menu_order'));
+		// run custom js script
+		wp_enqueue_script('ig-mpdf-settings', IG_MPDF_PATH . 'custom.js');
 
-    public function __construct() {
-        $this->pages = get_pages(array('sort_column' => 'menu_order'));
-        $this->pdf_link = null;
-
-        $this->generate_pdf();
-
-        wp_enqueue_script('ig-mpdf-settings', IG_MPDF_PATH . 'custom.js');
-        add_action( 'admin_menu', array( $this, 'add_plugin_page' ) );
-    }
-
-    /**
-     * Add options page
-     */
-    public function add_plugin_page() {
-        add_menu_page('PDF Export',
-            'PDF Export',
-            'read',
-            'ig-mpdf',
-            array( $this, 'create_admin_page' ),
-            'dashicons-format-aside'
-        );
-    }
-
-    /**
-     * Options page callback
-     */
-    public function create_admin_page() {
-        $pages = $this->add_pages_depth($this->pages);
-        ?>
-        <div class="wrap">
-            <?php if(!empty($this->pdf_link)): ?>
-                <?php if($this->pdf_link === false): ?>
-                    <div class="notice notice-error">
-                        <p>Bei der Erstellung der PDF-Datei ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.</p>
-                    </div>
-                <?php else: ?>
-                    <div class="notice notice-success">
-                        <p><a href="<?php echo $this->pdf_link; ?>" target="_blank">&raquo; PDF-Datei öffnen</a></p>
-                    </div>
-                <?php endif; ?>
-            <?php endif; ?>
-
-            <h1>PDF Export</h1>
-            <form method="post" action="admin.php?page=ig-mpdf">
-                <h3>Seiten zum Export auswählen:</h3>
-                <div id="check-all">
-                    <div>
-                        <label for="check_all">
-                            <input type="checkbox" name="check_all" id="check_all" />
-                            Alle an-/abwählen
-                        </label>
-                    </div>
-                </div>
-                <div class="pages">
-                    <?php $i = 0; ?>
-                    <?php foreach($pages as &$page): ?>
-                        <div class="page"
-                            style="padding-left:<?php echo $page['depth'] * 20; ?>px;">
-                            <label for="page<?php echo $i; ?>">
-                                <input id="page<?php echo $i; ?>" type="checkbox" name="page[]" value="<?php echo $page['id']; ?>" />
-                                <?php echo $page['title']; ?>
-                                (<?php
-                                    $de = get_the_title(apply_filters( 'wpml_object_id', $page['id'], 'page', TRUE, 'de' ));
-                                    if(!empty($de)) {
-                                        echo $de;
-                                    } else {
-                                        echo get_the_content(apply_filters( 'wpml_object_id', $page['id'], 'page', TRUE,
-                                            'en' ));
-                                    }
-                                ?>)
-                            </label>
-                        </div>
-                        <?php $i++; ?>
-                    <?php endforeach; ?>
-                </div>
-                <input type="hidden" name="ig_pdf_export_instance" value="<?php echo get_current_blog_id(); ?>" />
-                <input type="hidden" name="ig_pdf_export_language" value="<?php echo apply_filters('wpml_current_language', NULL); ?>" />
-                <input type="hidden" name="ig_pdf_export" value="true" />
-                <?php submit_button('Exportieren'); ?>
-            </form>
-        </div>
-        <style>
-            .pages .page {
-                margin-bottom: 5px;
-            }
-            #check-all {
-                margin-bottom: 15px;
-            }
-            #check-all div {
-                float: right;
-            }
-        </style>
-        <?php
-    }
-
-    /**
-     * Create corresponding database table
-     */
-    static function create_database_table() {
-        global $wpdb;
-
-        $sql = "
-        --
-        -- Table structure for table `wp_ig_mpdf`
-        --
-        
-        CREATE TABLE IF NOT EXISTS `wp_ig_mpdf` (
-          `id` int(10) NOT NULL AUTO_INCREMENT,
-          `pdf_name` TEXT NOT NULL,
-          `pages` TEXT NOT NULL,
-          `creation_date` TIMESTAMP NOT NULL,
-          `multiple` TINYINT(2) NOT NULL,
-          `instance` int(10) NOT NULL,
-          PRIMARY KEY (`id`)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;";
-
-        $wpdb->query($sql);
-    }
-
-    /**
-     * add depth level to pages
-     *
-     * @return array with pages (title, id, depth)
-     */
-    private function add_pages_depth() {
-        $out_pages = array();
-        for($i = 0; $i < count($this->pages); $i++) {
-            $out_pages[$i] = array(
-                'id'    => $this->pages[$i]->ID,
-                'title' => $this->pages[$i]->post_title,
-                'depth' => $this->estimate_page_depth($i),
-            );
-        }
-
-        return $out_pages;
-    }
-
-    /**
-     * find depth level of a page
-     *
-     * @param post_id
-     * @return mixed
-     */
-    private function estimate_page_depth($index) {
-        return $this->estimate_page_depth_recursion($this->pages[$index]->post_parent, 0);
-    }
-
-    /**
-     * find depth level of page (recursion)
-     *
-     * @param post_id
-     * @param level
-     * @return mixed level
-     */
-    private function estimate_page_depth_recursion($post_id, $level) {
-        if($post_id == 0) {
-            return $level;
-        }
-
-        $index = 0;
-        for($i = 0; $i < count($this->pages); $i++) {
-            if($this->pages[$i]->ID == $post_id) {
-                $index = $i;
-                break;
-            }
-        }
-
-        $level = $level + 1;
-        return $this->estimate_page_depth_recursion($this->pages[$index]->post_parent, $level);
-    }
-
-    /**
-     * Generates pdf and updates pdf link
-     */
-    private function generate_pdf() {
-        if(!empty($_POST['ig_pdf_export']) and $_POST['ig_pdf_export'] == 'true' and !empty($_POST['page'])) {
-            $pdf = new IntegreatMpdf($_POST['page'], $_POST['ig_pdf_export_instance'], $_POST['ig_pdf_export_language']);
-            $this->pdf_link = $pdf->get_pdf();
-        }
-    }
+        // include custom css file
+		$css_file = __DIR__ . '/css/styles.css';
+		if (is_file($css_file)) {
+			echo '<style>' . file_get_contents($css_file) . '</style>';
+		}
+		?>
+		<div class="wrap">
+			<h1>PDF Export</h1>
+			<form method="post" action="admin.php?page=ig-mpdf" id="ig-mpdf-form">
+				<h3><div>
+					<label for="toc">Inhaltsverzeichnis</label>
+					<label class="switch">
+						<input type="checkbox" name="toc" checked>
+						<span class="slider round"></span>
+					</label>
+				</div></h3>
+				<h3>Seiten zum Export auswählen:</h3>
+				<div id="check-all">
+					<div>
+						<label for="check_all">
+							<input type="checkbox" name="check_all" id="check_all" />
+							Alle an-/abwählen
+						</label>
+					</div>
+				</div>
+				<div class="pages">
+					<?php $i = 0; ?>
+					<?php foreach($pages as $page): ?>
+						<div class="page" style="padding-left:<?= count(get_post_ancestors($page)) * 20; ?>px;">
+							<label for="page<?= $i; ?>">
+								<input id="page<?= $i; ?>" type="checkbox" name="page[]" value="<?= $page->ID; ?>"/>
+								<?= $page->post_title; ?>
+                                <?php
+									if (apply_filters('wpml_current_language', null) !== 'de') {
+											echo '(' . get_the_title(apply_filters('wpml_object_id', $page->ID, 'page', true, 'de')) . ')';
+									}
+								?>
+							</label>
+						</div>
+						<?php $i++; ?>
+					<?php endforeach; ?>
+				</div>
+                <p class="submit"><input type="submit" name="submit" id="ig-mpdf-submit" class="button button-primary" value="Exportieren"/></p>
+			</form>
+		</div>
+		<?php
+	}
 
 }

--- a/wp-content/plugins/ig-mpdf/css/styles.css
+++ b/wp-content/plugins/ig-mpdf/css/styles.css
@@ -1,0 +1,71 @@
+.pages .page {
+    margin-bottom: 5px;
+}
+#check-all {
+    margin-bottom: 15px;
+}
+#check-all div {
+    float: right;
+}
+/* The switch - the box around the slider */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 23px;
+    padding-right: 0px;
+    margin-left: 20px;
+}
+
+/* Hide default HTML checkbox */
+.switch input {
+    display:none;
+}
+
+/* The slider */
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+input:checked + .slider {
+    background-color: #2196F3;
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+    -webkit-transform: translateX(16px);
+    -ms-transform: translateX(16px);
+    transform: translateX(16px);
+}
+
+/* Rounded sliders */
+.slider.round {
+    border-radius: 34px;
+}
+
+.slider.round:before {
+    border-radius: 50%;
+}

--- a/wp-content/plugins/ig-mpdf/custom.js
+++ b/wp-content/plugins/ig-mpdf/custom.js
@@ -1,9 +1,5 @@
 jQuery(document).ready(function () {
-    checkAll();
-});
-
-// check/uncheck all pages
-function checkAll() {
+    // check/uncheck all pages
     jQuery('#check-all input').click(function () {
         if(jQuery(this).prop('checked')) {
             jQuery('.pages .page').each(function() {
@@ -15,4 +11,13 @@ function checkAll() {
             });
         }
     });
-}
+    // open pdf in new tab if at least one page is selected
+    jQuery('#ig-mpdf-submit').click(function () {
+        jQuery('.pages .page').each(function() {
+            if(jQuery(this).find('input').prop('checked')) {
+                jQuery("#ig-mpdf-form").prop("target", '_blank');
+                return true;
+            }
+        });
+    });
+});

--- a/wp-content/plugins/ig-mpdf/plugin.php
+++ b/wp-content/plugins/ig-mpdf/plugin.php
@@ -1,8 +1,13 @@
 <?php
-/*
-Plugin Name: Integreat mpdf
-Description: Plugin for pdf exports of single and multiple sites via mpdf library
-Author:      Sascha Beele
+/**
+ * Plugin Name: Integreat mPDF
+ * Description: Plugin for pdf exports of single and multiple sites via mpdf library
+ * Version: 1.1
+ * Author: Integreat Team / Sascha Beele
+ * Author URI: https://github.com/Integreat
+ * License: MIT
+ * Text Domain: ig-mpdf
+ * Domain Path: /
  */
 
 include __DIR__ . '/IntegreatMpdf.php';
@@ -11,20 +16,41 @@ include __DIR__ . '/IntegreatMpdfSettings.php';
 
 // constant for plugin path
 if(!defined('IG_MPDF_PATH')) {
-    define('IG_MPDF_PATH', get_option('siteurl') . '/wp-content/plugins/ig-mpdf/');
+	define('IG_MPDF_PATH', get_option('siteurl') . '/wp-content/plugins/ig-mpdf/');
 }
 
-// create database table on activation
-function ig_mpdf_install() {
-    IntegreatMpdfSettings::create_database_table();
-}
-register_activation_hook( __FILE__, 'ig_mpdf_install' );
+add_action('init', function() {
+	// init API
+	new IntegreatMpdfAPI();
+	// process request if form was submitted (must run ad 'init' to enable pdf output)
+	if (isset($_POST['submit']) && $_SERVER['QUERY_STRING'] == 'page=ig-mpdf') {
+		if(isset($_POST['page'])) {
+			$mpdf = new IntegreatMpdf($_POST['page'], isset($_POST['toc']));
+			try {
+				$mpdf->get_pdf();
+			} catch (\Mpdf\MpdfException $e) {
+				echo '<div class="notice notice-error is-dismissible"><p><strong>' . $e->getMessage() . '</strong></p></div>';
+			}
+		} else {
+			echo '<div class="notice notice-warning is-dismissible"><p><strong>Bitte wählen Sie mindestens eine Seite aus.</strong></p></div>';
+		}
+	}
+});
 
-// init backend functionality and API
-function init_ig_mpdf() {
-    if(is_admin()) {
-        new IntegreatMpdfSettings();
-    }
-    new IntegreatMpdfAPI();
-}
-add_action('init', 'init_ig_mpdf');
+// add admin menu
+add_action(
+	'admin_menu',
+	function () {
+		add_menu_page(
+			'PDF Export',
+			'PDF Export',
+			'read',
+			'ig-mpdf',
+			[
+				'IntegreatMpdfSettings',
+				'create_admin_page'
+			],
+			'dashicons-format-aside'
+		);
+	}
+);


### PR DESCRIPTION
- refactor ig-mpdf (uses the php-inbuilt function `filemtime()` instead of the custom sql-tables to determine the modified timestamp of the pdf files)
- generate a table of contents if the pdf of a a category is generated via the webapp
- add the option to generate a table of contents if the pdf is generated via the cms backend (resolves #711)