### PR TITLE
[ig-mpdf] support more levels in toc

### DIFF
--- a/wp-content/plugins/ig-mpdf/IntegreatMpdf.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdf.php
@@ -77,28 +77,13 @@ class IntegreatMpdf {
 			$this->mpdf->SetDirectionality('rtl');
 		}
 		// head
-		$head = '	<html>
-						<head>
-							<style>
-								body {
-									font-family: "sans-serif";
-									font-size:   14px;
-									color:	   #000000;
-									line-height: 1.4;
-								}
-								.page {
-									margin-bottom:  35px;
-									padding-bottom: 35px;
-								}
-								.page-border {
-									border-bottom: 3px solid #BBBBBB;
-								}
-								.header_footer {
-									color: #666666;
-								}
-							</style>
-						</head>
-					<body>';
+		$head = '<html><head>';
+		// include custom css file
+		$css_file = __DIR__ . '/css/pdf.css';
+		if (is_file($css_file)) {
+			$head .= '<style>' . file_get_contents($css_file) . '</style>';
+		}
+		$head .= '</head><body>';
 		$this->mpdf->WriteHTML($head);
 
 		// TOC

--- a/wp-content/plugins/ig-mpdf/css/pdf.css
+++ b/wp-content/plugins/ig-mpdf/css/pdf.css
@@ -1,0 +1,47 @@
+body {
+	font-family: "sans-serif";
+	font-size:   14px;
+	color:	   #000000;
+	line-height: 1.4;
+}
+
+.page {
+	margin-bottom:  35px;
+	padding-bottom: 35px;
+}
+
+.page-border {
+	border-bottom: 3px solid #BBBBBB;
+}
+
+.header_footer {
+	color: #666666;
+}
+
+div.mpdf_toc_level_3 {
+	margin-left: 6em;
+}
+
+div.mpdf_toc_level_4 {
+	margin-left: 8em;
+}
+
+div.mpdf_toc_level_5 {
+	margin-left: 10em;
+}
+
+div.mpdf_toc_level_6 {
+	margin-left: 12em;
+}
+
+div.mpdf_toc_level_7 {
+	margin-left: 14em;
+}
+
+div.mpdf_toc_level_8 {
+	margin-left: 16em;
+}
+
+div.mpdf_toc_level_9 {
+	margin-left: 18em;
+}


### PR DESCRIPTION
At the moment the table of contents of our mpdf-plugin does not support subpages which have 3 or more ancestors (they are shown as top-level-pages).
I solved this by adding some custom css for the pdf file, which increases the left margin of entries by 2em per level.