### PR TITLE
[api-v3] return language list instead of object

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Languages.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Languages.php
@@ -8,7 +8,7 @@ class APIv3_Languages extends APIv3_Base_Abstract {
 	const ROUTE = 'languages';
 
 	public function get_languages() {
-		return array_map([$this, 'prepare'], (apply_filters('wpml_active_languages', null, '')));
+		return array_map([$this, 'prepare'], array_values(apply_filters('wpml_active_languages', null, '')));
 	}
 
 	private function prepare(Array $language) {


### PR DESCRIPTION
At the moment, wpml returns the languages in a weird object with language codes as keys (which is redundant because they are already contained in the values). To stay consistent with the other endpoints, we reset the array keys, which results in a json-list instead of an object.