### PR TITLE
Fix deactivate single blog API tracking

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/helper/PiwikHelper.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/helper/PiwikHelper.php
@@ -5,7 +5,7 @@ function ig_api_page_tracking ( $call_name ) {
      * Contact Tracking server and save API hit
      */
     $token = get_blog_option(get_current_blog_id(), "wp-piwik_global-piwik_token");
-    if ( !$token || !is_plugin_active('wp-piwik') ) {
+    if ( !$token ) {
         $token = PIWIK_DEFAULT_AUTH_TOKEN;
         $idSite = PIWIK_DEFAULT_SITE_ID;
     } else {


### PR DESCRIPTION
* To deactivate tracking for a blog, first set token to empty string, then deactivate plugin