### PR TITLE
[ig-feedback] add APIv3 feedback endpoint for comments

### DIFF
--- a/wp-admin/includes/class-wp-comments-list-table.php
+++ b/wp-admin/includes/class-wp-comments-list-table.php
@@ -744,6 +744,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 	 * @param WP_Comment $comment The comment object.
 	 */
 	public function column_response( $comment ) {
+		apply_filters('ig_feedback_response', $comment);
 		$post = get_post();
 
 		if ( ! $post ) {

--- a/wp-admin/includes/class-wp-comments-list-table.php
+++ b/wp-admin/includes/class-wp-comments-list-table.php
@@ -744,7 +744,6 @@ class WP_Comments_List_Table extends WP_List_Table {
 	 * @param WP_Comment $comment The comment object.
 	 */
 	public function column_response( $comment ) {
-		apply_filters('ig_feedback_response', $comment);
 		$post = get_post();
 
 		if ( ! $post ) {

--- a/wp-content/plugins/ig-feedback/plugin.php
+++ b/wp-content/plugins/ig-feedback/plugin.php
@@ -9,44 +9,105 @@
  */
 
 /*
- * Add a custom rating column in the comments table behind the comment
+ * Allow duplicate comments (for ratings without comment message)
+ */
+add_filter('duplicate_comment_id', '__return_false');
+
+/*
+ * Disable translations for comments
+ */
+add_action( 'plugins_loaded', function () {
+	remove_filter('comments_clauses', [$GLOBALS['sitepress'], 'comments_clauses'], 10);
+} );
+
+/*
+ * Add custom columns to the comments table
  */
 add_filter('manage_edit-comments_columns', function ($columns){
-	return array_slice($columns, 0, 3, true) + ['ig_comment_rating' => 'Bewertung'] + array_slice($columns, 3, null, true);
+	return [
+		'cb' => '<input type="checkbox" />',
+		'ig_response' => 'Feedback zu',
+		'ig_rating' => 'Bewertung',
+		'ig_content' => 'Kommentare',
+	];
 });
 
 /*
  * Define the custom rating column by checking the rating meta and fill the stars accordingly
  */
 add_action('manage_comments_custom_column', function ($column, $comment_id) {
-	if ($column == 'ig_comment_rating') {
-		$rating = get_comment_meta($comment_id, 'rating', true);
-		if ($rating !== '' && $rating !== null) {
-			wp_star_rating(['rating' => $rating]);
-		}
+	switch ($column) {
+		case 'ig_response':
+			$type = get_comment_meta($comment_id, 'type', true);
+			switch ($type) {
+				case 'post':
+					$post = get_post(get_comment($comment_id)->comment_post_ID);
+					echo $post->post_title . '<br>
+						<a href="' . get_permalink($post) . '">Diese Seite ansehen</a><br>
+						<a href="' . get_edit_post_link($post->ID) . '">Diese Seite bearbeiten</a>';
+					break;
+				case 'categories':
+					echo 'Verfügbare Kategorien';
+					break;
+				case 'cities':
+					echo 'Verfügbare Städte';
+					break;
+				case 'events':
+					echo 'Verfügbare Veranstaltungen';
+					break;
+				case 'extra':
+					$alias = get_comment_meta($comment_id, 'alias', true);
+					if (class_exists('IntegreatSettingsPlugin') && $extra = IntegreatExtra::get_extra_by_alias($alias)) {
+						echo 'Extra "' . $extra->name . '"';
+					} else {
+						echo 'Extra "' . $alias . '"';
+					}
+					break;
+				case 'extras':
+					echo 'Verfügbare Extras';
+					break;
+				case 'search':
+					echo 'Suchergebnisse zu "' . get_comment_meta($comment_id, 'query', true) . '"';
+					break;
+			}
+			break;
+		case 'ig_rating':
+			$rating_up = get_comment_meta($comment_id, 'rating_up', true);
+			$rating_down = get_comment_meta($comment_id, 'rating_down', true);
+			if ($rating_up > 0) {
+				echo '<span class="dashicons dashicons-thumbs-up"></span> ' . $rating_up . '<br>';
+			}
+			if ($rating_down > 0) {
+				echo '<span class="dashicons dashicons-thumbs-down"></span> ' . $rating_down . '<br>';
+			}
+			break;
+		case 'ig_content':
+			$content = json_decode(get_comment_meta($comment_id, 'content', true));
+			if (count($content) > 0) {
+				echo '<a href="#" class="ig-feedback-spoiler-show" data-ig-feedback-comment-id="' . $comment_id . '">Ausklappen</a>';
+				echo '<a href="#" class="ig-feedback-spoiler-hide" data-ig-feedback-comment-id="' . $comment_id . '">Einklappen</a>';
+				echo '<div class="ig-feedback-spoiler-content" data-ig-feedback-comment-id="' . $comment_id . '">';
+				foreach ($content as $item) {
+					echo '<hr><i>' . $item->date . '</i>';
+					if ($item->language !== 'de') {
+						echo ' - <i>Kommentar zu übersetztem Inhalt (' . $item->language . ')</i>';
+					}
+					echo '<br>';
+					if ($item->category) {
+						echo '<b>' . $item->category . ':</b> ';
+					}
+					echo $item->text;
+				}
+				echo '</div>';
+			}
+			break;
 	}
 }, 10, 2 );
 
 /*
- * Adjust the size of the custom rating column
+ * Include custom javascript and css
  */
-add_action('admin_head', function () {
-	echo '<style>#ig_comment_rating {width: 120px;}</style>';
-});
-
-/*
- * Add a filter to show information about comments which have no actual post, e.g. extras and searches
- */
-add_filter('ig_feedback_response', function ($comment) {
-	if ($comment->comment_post_ID) {
-		return;
-	}
-	$extra = get_comment_meta($comment->comment_ID, 'extra', true);
-	$query = get_comment_meta($comment->comment_ID, 'query', true);
-	$url = get_comment_meta($comment->comment_ID, 'url', true);
-	if ($extra !== '' && $extra !== null) {
-		echo esc_html($extra) . '<div class="response-links"><a href="' . $url . '" target="_BLANK" class="comments-view-item-link">Extra ansehen</a></div>';
-	} elseif ($query !== '' && $query !== null) {
-		echo 'Suche nach "' . esc_html($query) . '"' . '<div class="response-links"><a href="' . $url . '" target="_BLANK" class="comments-view-item-link">Suchergebnisse ansehen</a></div>';
-	}
+add_action( 'admin_enqueue_scripts', function () {
+	wp_enqueue_script('ig_feedback_script', plugin_dir_url(__FILE__) . 'script.js', ['jquery']);
+	wp_enqueue_style('ig_feedback_stylesheet', plugin_dir_url(__FILE__) . 'stylesheet.css');
 });

--- a/wp-content/plugins/ig-feedback/plugin.php
+++ b/wp-content/plugins/ig-feedback/plugin.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Plugin Name: Integreat Feedback
+ * Description: Adds a custom post type for feedback
+ * Version: 1.0
+ * Author: Integreat Team / Timo Ludwig
+ * Author URI: https://github.com/Integreat
+ * License: MIT
+ */
+
+/*
+ * Add a custom rating column in the comments table behind the comment
+ */
+add_filter('manage_edit-comments_columns', function ($columns){
+	return array_slice($columns, 0, 3, true) + ['ig_comment_rating' => 'Bewertung'] + array_slice($columns, 3, null, true);
+});
+
+/*
+ * Define the custom rating column by checking the rating meta and fill the stars accordingly
+ */
+add_action('manage_comments_custom_column', function ($column, $comment_id) {
+	if ($column == 'ig_comment_rating') {
+		$rating = get_comment_meta($comment_id, 'rating', true);
+		if ($rating !== '' && $rating !== null) {
+			wp_star_rating(['rating' => $rating]);
+		}
+	}
+}, 10, 2 );
+
+/*
+ * Adjust the size of the custom rating column
+ */
+add_action('admin_head', function () {
+	echo '<style>#ig_comment_rating {width: 120px;}</style>';
+});
+
+/*
+ * Add a filter to show information about comments which have no actual post, e.g. extras and searches
+ */
+add_filter('ig_feedback_response', function ($comment) {
+	if ($comment->comment_post_ID) {
+		return;
+	}
+	$extra = get_comment_meta($comment->comment_ID, 'extra', true);
+	$query = get_comment_meta($comment->comment_ID, 'query', true);
+	$url = get_comment_meta($comment->comment_ID, 'url', true);
+	if ($extra !== '' && $extra !== null) {
+		echo esc_html($extra) . '<div class="response-links"><a href="' . $url . '" target="_BLANK" class="comments-view-item-link">Extra ansehen</a></div>';
+	} elseif ($query !== '' && $query !== null) {
+		echo 'Suche nach "' . esc_html($query) . '"' . '<div class="response-links"><a href="' . $url . '" target="_BLANK" class="comments-view-item-link">Suchergebnisse ansehen</a></div>';
+	}
+});

--- a/wp-content/plugins/ig-feedback/script.js
+++ b/wp-content/plugins/ig-feedback/script.js
@@ -1,0 +1,5 @@
+jQuery(document).ready(function(){
+  jQuery('.ig-feedback-spoiler-show, .ig-feedback-spoiler-hide').click(function(){
+      jQuery("[data-ig-feedback-comment-id='" + jQuery(this).data('ig-feedback-comment-id') + "']").toggle('fast');
+  })
+});

--- a/wp-content/plugins/ig-feedback/stylesheet.css
+++ b/wp-content/plugins/ig-feedback/stylesheet.css
@@ -1,0 +1,11 @@
+#ig_rating {
+    width: 120px;
+}
+
+.ig-feedback-spoiler-content {
+    display: none;
+}
+
+.ig-feedback-spoiler-hide {
+    display: none;
+}

--- a/wp-content/plugins/ig-plugin-adjustment/plugin.php
+++ b/wp-content/plugins/ig-plugin-adjustment/plugin.php
@@ -14,8 +14,6 @@ add_action('upgrader_process_complete', function ($upgrader_object, $options) {
 		if (in_array('sitepress-multilingual-cms', $options['plugins'])) {
 			PluginAdjustment::apply_wpml_adjustment();
 		}
-	} elseif ($options['type'] === 'core') {
-		PluginAdjustment::apply_wp_comments_adjustment();
 	}
 }, 10, 2);
 
@@ -54,16 +52,6 @@ abstract class PluginAdjustment {
 				if (statuses && statuses.length) {
 					urlData.post_status = statuses.join(\',\');
 				}';
-		self::replace_in_file($file_path, $search, $replace);
-	}
-
-	static function apply_wp_comments_adjustment() {
-		$file_path = get_home_path() . 'wp-admin/includes/class-wp-comments-list-table.php';
-		$search = 'public function column_response( $comment ) {
-		$post = get_post();';
-		$replace = 'public function column_response( $comment ) {
-		apply_filters(\'ig_feedback_response\', $comment);
-		$post = get_post();';
 		self::replace_in_file($file_path, $search, $replace);
 	}
 

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Base_Abstract.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Base_Abstract.php
@@ -22,4 +22,13 @@ abstract class APIv3_Base_Abstract {
             'args' => $this->args
 		]);
 	}
+
+	/*
+	 * Test whether a given id has a corresponding published post.
+	 */
+	protected function is_valid($id) {
+		$post = get_post($id);
+		return $post !== null && $post->post_status == 'publish';
+	}
+
 }

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
@@ -8,16 +8,163 @@ abstract class APIv3_Feedback_Abstract extends APIv3_Base_Abstract {
 		$this->callback = 'put_feedback';
 		$this->args = [
 			'comment' => [
-				'required' => true,
 				'validate_callback' => function($comment) {
 					return is_string($comment);
 				}
 			],
-			'rating' => [
-				'validate_callback' => function($rating) {
-					return in_array($rating, [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]);
+			'category' => [
+				'validate_callback' => function($category) {
+					return is_string($category);
 				}
 			],
+			'rating' => [
+				'validate_callback' => function($rating) {
+					return in_array($rating, ['up', 'down']);
+				}
+			],
+		];
+	}
+
+	public function put_feedback(WP_REST_Request $request) {
+		$text = $request->get_param('comment');
+		$rating = $request->get_param('rating');
+		/*
+		 * Throw an error if both comment and rating are missing
+		 */
+		if ($text === null && $rating === null) {
+			return new WP_Error('rest_missing_param', 'Either the comment or the rating parameter is required', ['status' => 400]);
+		}
+		/*
+		 * If type is post, get the correct post id
+		 */
+		if (static::TYPE === 'post') {
+			$id = $request->get_param('id');
+			$permalink = $request->get_param('permalink');
+			/*
+			 * Throw an error if both id and permalink are missing
+			 */
+			if ($id === null && $permalink === null) {
+				return new WP_Error('rest_missing_param', 'Either the id or the permalink parameter is required', ['status' => 400]);
+			}
+			if ($id === null) {
+				$id = url_to_postid($permalink);
+			}
+			$language = apply_filters('wpml_post_language_details', null, $id)['language_code'];
+			$id = apply_filters('wpml_object_id', $id, 'any', true, 'de');
+		} else {
+			$language = apply_filters('wpml_current_language', null);
+			$id = null;
+		}
+		/*
+		 * Generate query dependent on meta keys
+		 */
+		if (defined('static::META')) {
+			$query = [
+				'post_id' => $id,
+				'meta_query' => [
+					'relation' => 'AND',
+					[
+						'key' => 'type',
+						'value' => static::TYPE
+					],
+					[
+						'key' => static::META,
+						'value' => $request->get_param(static::META)
+					]
+				]
+			];
+		} else {
+			$query = [
+				'post_id' => $id,
+				'meta_key' => 'type',
+				'meta_value' => static::TYPE
+			];
+		}
+		/*
+		 * Fetch all comments to the given post incl. the comment meta
+		 */
+		$comments = (new WP_Comment_Query($query))->comments;
+		$num_comments = count($comments);
+		if ($num_comments === 0) {
+			/*
+			 * If there are no comments for the given post, we add a new comment incl. comment meta
+			 */
+			$comment_id = wp_insert_comment([
+				'comment_post_ID' => $id,
+				'comment_content' => '',
+				'comment_author_IP' => '',
+				'comment_approved' => 0,
+			]);
+			/*
+			 * Return error if something went wrong
+			 */
+			if (!$comment_id) {
+				return new WP_Error('internal_server_error', 'Feedback could not be submitted.', ['status' => 500]);
+			}
+			add_comment_meta($comment_id, 'type', static::TYPE);
+			$content = [];
+			if ($text !== null) {
+				$content[] = [
+					'date' => date('d.m.Y H:i:s'),
+					'language' => $language,
+					'category' => $request->get_param('category'),
+					'text' => $text,
+				];
+			}
+			add_comment_meta($comment_id, 'content', json_encode($content));
+			if ($rating === 'up') {
+				add_comment_meta($comment_id, 'rating_up', 1);
+				add_comment_meta($comment_id, 'rating_down', 0);
+			} elseif ($rating === 'down') {
+				add_comment_meta($comment_id, 'rating_up', 0);
+				add_comment_meta($comment_id, 'rating_down', 1);
+			}
+			if (defined('static::META')) {
+				add_comment_meta($comment_id, static::META, $request->get_param(static::META));
+			}
+		} elseif ($num_comments === 1) {
+			/*
+			 * If there exists exactly one comment for the given post, we update the comment meta
+			 */
+			if ($rating === 'up') {
+				$rating_up_old = (int) get_comment_meta($comments[0]->comment_ID, 'rating_up', true);
+				update_comment_meta($comments[0]->comment_ID, 'rating_up', $rating_up_old + 1);
+			} elseif ($rating === 'down') {
+				$rating_down_old = (int) get_comment_meta($comments[0]->comment_ID, 'rating_down', true);
+				update_comment_meta($comments[0]->comment_ID, 'rating_down', $rating_down_old + 1);
+			}
+			if ($text !== null) {
+				$content = json_decode(get_comment_meta($comments[0]->comment_ID, 'content', true));
+				$content[] = [
+					'date' => date('d.m.Y H:i:s'),
+					'language' => $language,
+					'category' => $request->get_param('category'),
+					'text' => $text,
+				];
+				update_comment_meta($comments[0]->comment_ID, 'content', json_encode($content));
+				/*
+				 * If comment was approved before, unapprove it to mark it red in admin view
+				 */
+				wp_update_comment([
+					'comment_ID' => $comments[0]->comment_ID,
+					'comment_approved' => 0,
+				]);
+			}
+		} else {
+			/*
+			 * Throw an error if more than one comment exists
+			 */
+			return new WP_Error('rest_invalid_post', 'An internal error occured. Please contact the server administrator.', ['status' => 500]);
+		}
+		/*
+		 * Return success message if no error was returned until now
+		 */
+		return [
+			'code' =>'rest_comment_created',
+			'message' => 'Feedback successfully submitted',
+			'data' => [
+				'status' => 201,
+			]
 		];
 	}
 

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
@@ -1,0 +1,24 @@
+<?php
+
+abstract class APIv3_Feedback_Abstract extends APIv3_Base_Abstract {
+
+	public function __construct() {
+		parent::__construct();
+		$this->method = 'POST';
+		$this->callback = 'put_feedback';
+		$this->args = [
+			'comment' => [
+				'required' => true,
+				'validate_callback' => function($comment) {
+					return is_string($comment);
+				}
+			],
+			'rating' => [
+				'validate_callback' => function($rating) {
+					return in_array($rating, [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]);
+				}
+			],
+		];
+	}
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Categories.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Categories.php
@@ -1,0 +1,8 @@
+<?php
+
+class APIv3_Feedback_Categories extends APIv3_Feedback_Abstract {
+
+	const ROUTE = 'feedback/categories';
+	const TYPE = 'categories';
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Cities.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Cities.php
@@ -1,0 +1,8 @@
+<?php
+
+class APIv3_Feedback_Cities extends APIv3_Feedback_Abstract {
+
+	const ROUTE = 'feedback/cities';
+	const TYPE = 'cities';
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Events.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Events.php
@@ -1,0 +1,8 @@
+<?php
+
+class APIv3_Feedback_Events extends APIv3_Feedback_Abstract {
+
+	const ROUTE = 'feedback/events';
+	const TYPE = 'events';
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Extra.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Extra.php
@@ -3,37 +3,20 @@
 class APIv3_Feedback_Extra extends APIv3_Feedback_Abstract {
 
 	const ROUTE = 'feedback/extra';
+	const TYPE = 'extra';
+	const META = 'alias';
 
 	public function __construct() {
 		parent::__construct();
-		$this->args['url'] = [
+		$this->args['alias'] = [
 			'required' => true,
-			'validate_callback' => function($url) {
-				return filter_var($url, FILTER_VALIDATE_URL);
+			'validate_callback' => function($alias) {
+				if (class_exists('IntegreatSettingsPlugin')) {
+					return (bool) IntegreatExtra::get_extra_by_alias($alias);
+				}
+				return false;
 			}
 		];
-		$this->args['extra'] = [
-			'required' => true,
-			'validate_callback' => function($extra) {
-				return is_string($extra);
-			}
-		];
-	}
-
-	public function put_feedback(WP_REST_Request $request) {
-		$url = $request->get_param('url');
-		$extra = $request->get_param('extra');
-		$comment_id = wp_new_comment([
-			'comment_content' => $request->get_param('comment'),
-			'comment_author_IP' => ''
-		], true);
-		if (is_wp_error($comment_id)) {
-			return $comment_id;
-		}
-		add_comment_meta($comment_id, 'rating', $request->get_param('rating'));
-		add_comment_meta($comment_id, 'extra', $extra);
-		add_comment_meta($comment_id, 'url', $url);
-		return new WP_Error('rest_comment_created', 'Feedback successfully submitted', ['status' => 201]);
 	}
 
 }

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Extra.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Extra.php
@@ -1,0 +1,39 @@
+<?php
+
+class APIv3_Feedback_Extra extends APIv3_Feedback_Abstract {
+
+	const ROUTE = 'feedback/extra';
+
+	public function __construct() {
+		parent::__construct();
+		$this->args['url'] = [
+			'required' => true,
+			'validate_callback' => function($url) {
+				return filter_var($url, FILTER_VALIDATE_URL);
+			}
+		];
+		$this->args['extra'] = [
+			'required' => true,
+			'validate_callback' => function($extra) {
+				return is_string($extra);
+			}
+		];
+	}
+
+	public function put_feedback(WP_REST_Request $request) {
+		$url = $request->get_param('url');
+		$extra = $request->get_param('extra');
+		$comment_id = wp_new_comment([
+			'comment_content' => $request->get_param('comment'),
+			'comment_author_IP' => ''
+		], true);
+		if (is_wp_error($comment_id)) {
+			return $comment_id;
+		}
+		add_comment_meta($comment_id, 'rating', $request->get_param('rating'));
+		add_comment_meta($comment_id, 'extra', $extra);
+		add_comment_meta($comment_id, 'url', $url);
+		return new WP_Error('rest_comment_created', 'Feedback successfully submitted', ['status' => 201]);
+	}
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Extras.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Extras.php
@@ -1,0 +1,8 @@
+<?php
+
+class APIv3_Feedback_Extras extends APIv3_Feedback_Abstract {
+
+	const ROUTE = 'feedback/extras';
+	const TYPE = 'extras';
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
@@ -3,6 +3,7 @@
 class APIv3_Feedback_Post extends APIv3_Feedback_Abstract {
 
 	const ROUTE = 'feedback';
+	const TYPE = 'post';
 
 	public function __construct() {
 		parent::__construct();
@@ -11,33 +12,11 @@ class APIv3_Feedback_Post extends APIv3_Feedback_Abstract {
 				return $this->is_valid($id);
 			}
 		];
-		$this->args['url'] = [
-			'validate_callback' => function($url) {
-				return $this->is_valid(url_to_postid($url));
+		$this->args['permalink'] = [
+			'validate_callback' => function($permalink) {
+				return $this->is_valid(url_to_postid($permalink));
 			}
 		];
-	}
-
-	public function put_feedback(WP_REST_Request $request) {
-		$id = $request->get_param('id');
-		$url = $request->get_param('url');
-		if ($id !== null || $url !== null) {
-			if ($id === null) {
-				$id = url_to_postid($url);
-			}
-			$comment_id = wp_new_comment([
-				'comment_post_ID' => $id,
-				'comment_content' => $request->get_param('comment'),
-				'comment_author_IP' => ''
-			], true);
-			if (is_wp_error($comment_id)) {
-				return $comment_id;
-			}
-			add_comment_meta($comment_id, 'rating', $request->get_param('rating'));
-			return new WP_Error('rest_comment_created', 'Feedback successfully submitted', ['status' => 201]);
-		} else {
-			return new WP_Error('rest_missing_param', 'Either the id or the url parameter is required', ['status' => 400]);
-		}
 	}
 
 }

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
@@ -1,0 +1,43 @@
+<?php
+
+class APIv3_Feedback_Post extends APIv3_Feedback_Abstract {
+
+	const ROUTE = 'feedback';
+
+	public function __construct() {
+		parent::__construct();
+		$this->args['id'] = [
+			'validate_callback' => function($id) {
+				return $this->is_valid($id);
+			}
+		];
+		$this->args['url'] = [
+			'validate_callback' => function($url) {
+				return $this->is_valid(url_to_postid($url));
+			}
+		];
+	}
+
+	public function put_feedback(WP_REST_Request $request) {
+		$id = $request->get_param('id');
+		$url = $request->get_param('url');
+		if ($id !== null || $url !== null) {
+			if ($id === null) {
+				$id = url_to_postid($url);
+			}
+			$comment_id = wp_new_comment([
+				'comment_post_ID' => $id,
+				'comment_content' => $request->get_param('comment'),
+				'comment_author_IP' => ''
+			], true);
+			if (is_wp_error($comment_id)) {
+				return $comment_id;
+			}
+			add_comment_meta($comment_id, 'rating', $request->get_param('rating'));
+			return new WP_Error('rest_comment_created', 'Feedback successfully submitted', ['status' => 201]);
+		} else {
+			return new WP_Error('rest_missing_param', 'Either the id or the url parameter is required', ['status' => 400]);
+		}
+	}
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Search.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Search.php
@@ -1,0 +1,39 @@
+<?php
+
+class APIv3_Feedback_Search extends APIv3_Feedback_Abstract {
+
+	const ROUTE = 'feedback/search';
+
+	public function __construct() {
+		parent::__construct();
+		$this->args['url'] = [
+			'required' => true,
+			'validate_callback' => function($url) {
+				return filter_var($url, FILTER_VALIDATE_URL);
+			}
+		];
+		$this->args['query'] = [
+			'required' => true,
+			'validate_callback' => function($query) {
+				return is_string($query);
+			}
+		];
+	}
+
+	public function put_feedback(WP_REST_Request $request) {
+		$url = $request->get_param('url');
+		$query = $request->get_param('query');
+		$comment_id = wp_new_comment([
+			'comment_content' => $request->get_param('comment'),
+			'comment_author_IP' => ''
+		], true);
+		if (is_wp_error($comment_id)) {
+			return $comment_id;
+		}
+		add_comment_meta($comment_id, 'rating', $request->get_param('rating'));
+		add_comment_meta($comment_id, 'query', $query);
+		add_comment_meta($comment_id, 'url', $url);
+		return new WP_Error('rest_comment_created', 'Feedback successfully submitted', ['status' => 201]);
+	}
+
+}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Search.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Search.php
@@ -3,37 +3,17 @@
 class APIv3_Feedback_Search extends APIv3_Feedback_Abstract {
 
 	const ROUTE = 'feedback/search';
+	const TYPE = 'search';
+	const META = 'query';
 
 	public function __construct() {
 		parent::__construct();
-		$this->args['url'] = [
-			'required' => true,
-			'validate_callback' => function($url) {
-				return filter_var($url, FILTER_VALIDATE_URL);
-			}
-		];
 		$this->args['query'] = [
 			'required' => true,
 			'validate_callback' => function($query) {
 				return is_string($query);
 			}
 		];
-	}
-
-	public function put_feedback(WP_REST_Request $request) {
-		$url = $request->get_param('url');
-		$query = $request->get_param('query');
-		$comment_id = wp_new_comment([
-			'comment_content' => $request->get_param('comment'),
-			'comment_author_IP' => ''
-		], true);
-		if (is_wp_error($comment_id)) {
-			return $comment_id;
-		}
-		add_comment_meta($comment_id, 'rating', $request->get_param('rating'));
-		add_comment_meta($comment_id, 'query', $query);
-		add_comment_meta($comment_id, 'url', $url);
-		return new WP_Error('rest_comment_created', 'Feedback successfully submitted', ['status' => 201]);
 	}
 
 }

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Post.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Post.php
@@ -12,13 +12,13 @@ class APIv3_Posts_Post extends APIv3_Posts_Abstract {
 			'id' => [
 				'required' => false,
 				'validate_callback' => function($id) {
-					return is_numeric($id);
+					return $this->is_valid($id);
 				}
 			],
 			'url' => [
 				'required' => false,
 				'validate_callback' => function($url) {
-					return filter_var($url, FILTER_VALIDATE_URL);
+					return $this->is_valid(url_to_postid($url));
 				}
 			]
 		];
@@ -27,22 +27,13 @@ class APIv3_Posts_Post extends APIv3_Posts_Abstract {
 	public function get_post(WP_REST_Request $request) {
 		$id = $request->get_param('id');
 		$url = $request->get_param('url');
-		if ($id !== null) {
-			$post = get_post($id);
-			if ($post === null) {
-				return new WP_Error('rest_no_post', 'No post was found for this ID', ['status' => 404]);
+		if ($id !== null || $url !== null) {
+			if ($id === null) {
+				$id = url_to_postid($url);
 			}
-		} elseif ($url !== null) {
-			$id = url_to_postid($url);
 			$post = get_post($id);
-			if ($post === null) {
-				return new WP_Error('rest_no_post', 'No post was found for this URL', ['status' => 404]);
-			}
 		} else {
-			return new WP_Error('rest_missing_param', 'Either the ID or the URL parameter is required', ['status' => 400]);
-		}
-		if ($post->post_status !== 'publish') {
-			return new WP_Error('rest_not_published', 'This post has not been published', ['status' => 403]);
+			return new WP_Error('rest_missing_param', 'Either the id or the url parameter is required', ['status' => 400]);
 		}
 		return $this->prepare($post);
 	}

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Relatives_Abstract.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Relatives_Abstract.php
@@ -41,9 +41,4 @@ abstract class APIv3_Posts_Relatives_Abstract extends APIv3_Posts_Abstract {
 		return $post;
 	}
 
-	private function is_valid($id) {
-		$post = get_post($id);
-		return $post !== null && $post->post_status == 'publish';
-	}
-
 }

--- a/wp-content/plugins/ig-wp-api-extensions/plugin.php
+++ b/wp-content/plugins/ig-wp-api-extensions/plugin.php
@@ -32,6 +32,10 @@ require_once __DIR__ . '/endpoints/v2/RestApi_ModifiedDisclaimer.php';
 // v3
 require_once __DIR__ . '/endpoints/v3/APIv3_Base_Abstract.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Extras.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Abstract.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Extra.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Post.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Search.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Languages.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Sites.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Sites_Hidden.php';
@@ -88,6 +92,9 @@ add_action('rest_api_init', function () {
 		],
 		3 => [
 			new APIv3_Extras(),
+			new APIv3_Feedback_Post(),
+			new APIv3_Feedback_Extra(),
+			new APIv3_Feedback_Search(),
 			new APIv3_Languages(),
 			new APIv3_Posts_Children(),
 			new APIv3_Posts_Disclaimer(),

--- a/wp-content/plugins/ig-wp-api-extensions/plugin.php
+++ b/wp-content/plugins/ig-wp-api-extensions/plugin.php
@@ -33,7 +33,11 @@ require_once __DIR__ . '/endpoints/v2/RestApi_ModifiedDisclaimer.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Base_Abstract.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Extras.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Abstract.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Categories.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Cities.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Events.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Extra.php';
+require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Extras.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Post.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Feedback_Search.php';
 require_once __DIR__ . '/endpoints/v3/APIv3_Languages.php';
@@ -93,7 +97,11 @@ add_action('rest_api_init', function () {
 		3 => [
 			new APIv3_Extras(),
 			new APIv3_Feedback_Post(),
+			new APIv3_Feedback_Categories(),
+			new APIv3_Feedback_Cities(),
+			new APIv3_Feedback_Events(),
 			new APIv3_Feedback_Extra(),
+			new APIv3_Feedback_Extras(),
 			new APIv3_Feedback_Search(),
 			new APIv3_Languages(),
 			new APIv3_Posts_Children(),


### PR DESCRIPTION
#### Short description of what this resolves:
- provides three new APIv3 endpoints to post feedback to pages, events, extras, search results, cities and categories

#### Changes proposed in this pull request:
- we use the comment functionality to implement feedback to pages and events
- we use comments to post with id 0 to indicate feedback about anything other than a post
- introduce an up- and down-voting counter
- text, rating, extra alias and search query are stored in custom comment meta fields
- change the structure of ig-plugin-adjustments to make it abstract

**Fixes:** #661:  

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
