### PR TITLE
[ig-mpdf] remove empty entry in TOC (fixes #735)

### DIFF
--- a/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
+++ b/wp-content/plugins/ig-mpdf/IntegreatMpdfAPI.php
@@ -49,7 +49,7 @@ class IntegreatMpdfAPI {
 			$GLOBALS['sitepress']->switch_lang(apply_filters('wpml_element_language_code', null, ['element_id' => $id, 'element_type' => 'page']), true);
 			$page_ids = $this->get_children($id);
 		} else {
-			$page_ids = array_slice($this->get_children(0), 0);
+			$page_ids = array_slice($this->get_children(0), 1);
 		}
 		$mpdf = new IntegreatMpdf($page_ids);
 		try {


### PR DESCRIPTION
#### Short description of what this resolves:
- removes the empty entry when generating PDFs for a whole instance

#### Changes proposed in this pull request:
- when the page ids for the pdf are generated, the page id 0 is also in the array what causes an empty entry in the TOC and the PDF's content. This is caused by a wrong usage of `array_slice()` (in fact, the function did exactly nothing before the patch) and I fixed it by changing the offset, which has the effect that the first value of the array (which is 0) will be removed.

Fixes: #735

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
