### PR TITLE
[api] only return pages with published ancestors (fixes #655)

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/RestApi_ExtensionBase.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/RestApi_ExtensionBase.php
@@ -9,6 +9,7 @@ abstract class RestApi_ExtensionBase {
 	private $default_route_options = [
 		'methods' => WP_REST_Server::READABLE,
 	];
+	protected $current_request;
 
 	public function __construct() {
 	}
@@ -25,4 +26,30 @@ abstract class RestApi_ExtensionBase {
 		$routeOptions = array_merge($this->default_route_options, $options);
 		register_rest_route($namespace, $baseRoute . $subPath, $routeOptions);
 	}
+
+	/**
+	 * Get all page ids of the given page and all its children in the correct order
+	 *
+	 * @param $id int|string
+	 * @return array
+	 */
+	protected function get_post_ids_recursive($id) {
+		$direct_children = (new WP_Query([
+			'post_type' => $this->current_request->post_type,
+			'post_status' => 'publish',
+			'post_parent' => $id,
+			'orderby' => 'menu_order post_title',
+			'order' => 'ASC',
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+		]))->posts;
+		if (empty($direct_children)) {
+			return [$id];
+		} else {
+			return array_reduce(array_map([$this, 'get_post_ids_recursive'], $direct_children), function ($all_children, $grand_children) {
+				return array_merge($all_children, $grand_children);
+			}, [$id]);
+		}
+	}
+
 }

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
@@ -228,8 +228,8 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 			'content' => ( $post->post_status != "trash" ? $content : "" ),
 			'parent' => $post->post_parent,
 			'order' => $post->menu_order,
-			'available_language_urls' => $this->wpml_helper->get_available_languages($post, map_post_to_foreign_language_url),
-			'available_languages' => $this->wpml_helper->get_available_languages($post, map_post_to_foreign_language_id),
+			'available_language_urls' => $this->wpml_helper->get_available_languages($post, 'map_post_to_foreign_language_url'),
+			'available_languages' => $this->wpml_helper->get_available_languages($post, 'map_post_to_foreign_language_id'),
 			'thumbnail' => $this->prepare_thumbnail($post),
 		];
 		$output_post = apply_filters('wp_api_extensions_output_post', $output_post);

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
@@ -32,7 +32,6 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 	private $datetime_input_format = DateTime::ATOM;
 	private $datetime_query_format = DateTime::ATOM;
 	private $datetime_zone_gmt;
-	private $current_request;
 
 	public function __construct() {
 		parent::__construct();
@@ -99,9 +98,11 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 			$query_result = array_merge($query_result, $recurring_events);
 		}
 
+		$post_ids = $this->get_post_ids_recursive(0);
+
 		$result = [];
 		foreach ($query_result as $post) {
-			if( isset($_GET['no_trash']) && $_GET['no_trash'] == '1' && $post->post_status == "trash" ) {
+			if((isset($_GET['no_trash']) && $_GET['no_trash'] == '1' && $post->post_status == "trash") || !in_array($post->ID, $post_ids)) {
 				continue;
 			}
 			$result[] = $this->prepare_item($post);

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v2/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v2/RestApi_ModifiedContent.php
@@ -32,7 +32,6 @@ abstract class RestApi_ModifiedContentV2 extends RestApi_ExtensionBase {
 	private $datetime_input_format = DateTime::ATOM;
 	private $datetime_query_format = DateTime::ATOM;
 	private $datetime_zone_gmt;
-	private $current_request;
 
 	public function __construct() {
 		parent::__construct();
@@ -99,9 +98,11 @@ abstract class RestApi_ModifiedContentV2 extends RestApi_ExtensionBase {
 			$query_result = array_merge($query_result, $recurring_events);
 		}
 
+		$post_ids = $this->get_post_ids_recursive(0);
+
 		$result = [];
 		foreach ($query_result as $post) {
-			if( isset($_GET['no_trash']) && $_GET['no_trash'] == '1' && $post->post_status == "trash" ) {
+			if((isset($_GET['no_trash']) && $_GET['no_trash'] == '1' && $post->post_status == "trash") || !in_array($post->ID, $post_ids)) {
 				continue;
 			}
 			$result[] = $this->prepare_item($post);
@@ -230,8 +231,8 @@ abstract class RestApi_ModifiedContentV2 extends RestApi_ExtensionBase {
 			'content' => ( $post->post_status != "trash" ? $content : "" ),
 			'parent' => $post->post_parent,
 			'order' => $post->menu_order,
-			'available_language_urls' => $this->wpml_helper->get_available_languages($post, map_post_to_foreign_language_url),
-			'available_languages' => $this->wpml_helper->get_available_languages($post, map_post_to_foreign_language_id),
+			'available_language_urls' => $this->wpml_helper->get_available_languages($post, 'map_post_to_foreign_language_url'),
+			'available_languages' => $this->wpml_helper->get_available_languages($post, 'map_post_to_foreign_language_id'),
 			'thumbnail' => $this->prepare_thumbnail($post),
 		];
 		$output_post = apply_filters('wp_api_extensions_output_post', $output_post);


### PR DESCRIPTION
#### Short description of what this resolves:
- pages with an unpublished parent are no longer delivered via the API

#### Changes proposed in this pull request:
- use a recurrent function to get all pages. This way, only the children of published pages are considered and all children of unpublished pages are ignored.
- in APIv3, we can use the recurrent function directly to fetch the posts
- in APIv0/v2, we have to use the recurrent function to get all page ids and test if each query result is contained in the post id array

Fixes: #655 



### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
