### PR TITLE
Display revisions meta box only for pages

### DIFF
--- a/wp-content/plugins/ig-revisions/plugin.php
+++ b/wp-content/plugins/ig-revisions/plugin.php
@@ -22,7 +22,7 @@ function ig_revisions_metabox( $post ) {
 		'ig_revisions',
 		__('Published revision', 'ig-revisions'),
 		'ig_revisions_metabox_html',
-		null,
+		'page',
 		'advanced',
 		'default',
 		$options


### PR DESCRIPTION
#### Short description of what this resolves:
Revision meta box is only shown on page edits.

#### Changes proposed in this pull request:
- Change add_meta_box parameter

**Fixes**: #
N/A


### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
