### PR TITLE
[ig-settings] add variable fields for wohnraumboerse (fixes #796)

### DIFF
--- a/wp-content/plugins/ig-settings/classes/IntegreatExtra.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatExtra.php
@@ -60,7 +60,7 @@ class IntegreatExtra {
 				'message' => 'You have to specify a URL for this extra'
 			];
 			self::$current_error[] = 'url';
-		} elseif (filter_var($this->url, FILTER_VALIDATE_URL) === false) {
+		} elseif (filter_var($this->url, FILTER_VALIDATE_URL) === false && $this->url !== '{wb_url}') {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
 				'message' => 'The given URL "' . htmlspecialchars($this->url) . '" is not valid'

--- a/wp-content/plugins/ig-settings/classes/IntegreatExtraConfig.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatExtraConfig.php
@@ -48,20 +48,22 @@ class IntegreatExtraConfig {
 			self::$current_error[] = 'extra_id';
 			return false;
 		}
-		$plz = $wpdb->get_var("SELECT value
+		foreach (['plz', 'wb_url', 'wb_api'] as $setting) {
+			$setting_value = $wpdb->get_var("SELECT value
 			FROM {$wpdb->base_prefix}ig_settings
 				AS settings
 			JOIN {$wpdb->prefix}ig_settings_config
 				AS config
 				ON settings.id = config.setting_id
-			WHERE settings.alias = 'plz'");
-		if ($this->enabled && (strpos($extra->url, '{plz}') !== false || strpos($extra->post, '{plz}') !== false) && !$plz){
-			IntegreatSettingsPlugin::$admin_notices[] = [
-				'type' => 'error',
-				'message' => 'The extra "' . htmlspecialchars($extra->name) . '" can not be enabled because it depends on the setting "plz" for this location'
-			];
-			self::$current_error[] = 'enabled';
-			return false;
+			WHERE settings.alias = '$setting'");
+			if ($this->enabled && (strpos($extra->url, "{$setting}") !== false || strpos($extra->post, "{$setting}") !== false) && !$setting_value){
+				IntegreatSettingsPlugin::$admin_notices[] = [
+					'type' => 'error',
+					'message' => 'The extra "' . htmlspecialchars($extra->name) . '" can not be enabled because it depends on the setting "' . $setting . '" for this location'
+				];
+				self::$current_error[] = 'enabled';
+				return false;
+			}
 		}
 		return true;
 	}

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -188,16 +188,8 @@ class IntegreatSettingsPlugin {
 		add_filter('ig-extras', function ($only_enabled = false) use ($wpdb) {
 			// fetch settings to enable the replacement of location-dependent content
 			$settings = apply_filters('ig-settings', null);
-			// replace umlaute to prevent wrong urls
-			$location = $wpdb->get_var(
-				"SELECT value
-					FROM {$wpdb->base_prefix}ig_settings
-						AS settings
-					LEFT JOIN {$wpdb->prefix}ig_settings_config
-						AS config
-						ON settings.id = setting_id
-					WHERE alias = 'location_override'");
-			if (!$location) {
+			if (!$location = $settings['location_override']) {
+				// replace umlaute to prevent wrong urls
 				$location = str_replace([' ', 'ä', 'ö', 'ü'], ['-', 'ae', 'oe', 'ue'], strtolower(apply_filters('ig-settings-legacy', $settings, 'name_without_prefix')));
 			}
 			$plz = apply_filters('ig-settings-legacy', $settings, 'plz');
@@ -210,11 +202,16 @@ class IntegreatSettingsPlugin {
 						AS config
 						ON extras.id = extra_id"
 				. ($only_enabled ? " WHERE enabled" : ""), OBJECT_K);
+			// fields for Wohnraumbörse
+			$wb_name = isset($settings['wb_name']) ? $settings['wb_name'] : 'Wohnraumbörse';
+			$wb_url = isset($settings['wb_url']) ? $settings['wb_url'] : '';
+			$wb_api = isset($settings['wb_api']) ? $settings['wb_api'] : '';
 			// filter all location-dependent content by replacing the placeholders
-			return array_map(function ($extra) use ($location, $plz) {
-					$extra->url = str_replace(['{location}', '{plz}'], [$location, $plz], $extra->url);
-					$extra->post = json_decode(str_replace(['{location}', '{plz}'], [$location, $plz], $extra->post));
-					return $extra;
+			return array_map(function ($extra) use ($location, $plz, $wb_name, $wb_url, $wb_api) {
+				$extra->name = str_replace('Wohnraumbörse', $wb_name, $extra->name);
+				$extra->url = str_replace(['{location}', '{plz}', '{wb_url}'], [$location, $plz, $wb_url], $extra->url);
+				$extra->post = json_decode(str_replace(['{location}', '{plz}', '{wb_api}'], [$location, $plz, $wb_api], $extra->post));
+				return $extra;
 				}, $extras
 			);
 		}, 10, 1);
@@ -222,18 +219,39 @@ class IntegreatSettingsPlugin {
 		 * Return all settings joined with the setting configurations
 		 */
 		add_filter('ig-settings', function () use ($wpdb) {
+			// get all settings
+			return array_map(function ($setting) {
+				// cast setting value by its desired type
+				return ($setting->type === 'bool' ? (bool) $setting->value : ($setting->value === '' ? null : $setting->value));
+			}, $wpdb->get_results(
+				"SELECT alias, type, value
+					FROM {$wpdb->base_prefix}ig_settings
+						AS settings
+					LEFT JOIN {$wpdb->prefix}ig_settings_config
+						AS config
+						ON settings.id = setting_id", OBJECT_K));
+		}, 10, 0);
+		/*
+		 * Return all settings relevant for APIv3 (joined with the setting configurations)
+		 */
+		add_filter('ig-settings-api', function () use ($wpdb) {
 			// get all settings and union it with an additional extra setting which is true if at least one extra is enabled
 			return array_map(function ($setting) {
-					// cast setting value by its desired type
-					return ($setting->type === 'bool' ? (bool) $setting->value : ($setting->value === '' ? null : $setting->value));
-				}, $wpdb->get_results(
-					"SELECT alias, type, value
+				// cast setting value by its desired type
+				return ($setting->type === 'bool' ? (bool) $setting->value : ($setting->value === '' ? null : $setting->value));
+			}, $wpdb->get_results(
+				"SELECT alias, type, value
 					FROM {$wpdb->base_prefix}ig_settings
 						AS settings
 					LEFT JOIN {$wpdb->prefix}ig_settings_config
 						AS config
 						ON settings.id = setting_id
-					WHERE alias != 'disabled' AND alias != 'hidden' AND alias != 'location_override'
+					WHERE
+						alias = 'prefix' OR
+						alias = 'name_without_prefix' OR
+						alias = 'plz' OR
+						alias = 'events' OR
+						alias = 'push-notifications'
 				UNION SELECT 'extras', 'bool', (SELECT enabled FROM {$wpdb->prefix}ig_extras_config WHERE enabled LIMIT 1)", OBJECT_K));
 		}, 10, 0);
 		/*

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -211,6 +211,7 @@ class IntegreatSettingsPlugin {
 				$extra->name = str_replace('Wohnraumbörse', $wb_name, $extra->name);
 				$extra->url = str_replace(['{location}', '{plz}', '{wb_url}'], [$location, $plz, $wb_url], $extra->url);
 				$extra->post = json_decode(str_replace(['{location}', '{plz}', '{wb_api}'], [$location, $plz, $wb_api], $extra->post));
+				$extra->thumbnail = str_replace('{wb_api}', $wb_api, $extra->thumbnail);
 				return $extra;
 				}, $extras
 			);

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Sites.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Sites.php
@@ -28,7 +28,7 @@ class APIv3_Sites extends APIv3_Base_Abstract {
 			$result['live'] = !$this->is_hidden($site);
 		}
 		if (class_exists('IntegreatSettingsPlugin')) {
-			$result = array_merge($result, apply_filters('ig-settings', null));
+			$result = array_merge($result, apply_filters('ig-settings-api', null));
 		}
 		restore_current_blog();
 		return $result;


### PR DESCRIPTION
#### Short description of what this resolves:
- adds the possibility to add more variable fields for the wohnraumbörse

#### Changes proposed in this pull request:
- adds new placeholder `wb_name`, `wb_url` and `wb_api` which can be used in the extra fields to support variable values in the wohnraumbörse extra

Fixes: #796 

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
