### PR TITLE
Remove user information from APIv0 to 2, fixes #806

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
@@ -251,14 +251,6 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 		return $image_src[0];
 	}
 
-	protected function prepare_author($post) {
-		return [
-			'login' => $post->user_login,
-			'first_name' => $post->author_firstname,
-			'last_name' => $post->author_lastname
-		];
-	}
-
 	protected function prepare_url($post){
 		$page_id = $post->ID;
 		$date = $post->post_modified_gmt;

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
@@ -149,8 +149,7 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 	 */
 	protected function build_query_select() {
 		return "posts.ID, posts.post_title, posts.post_type, posts.post_status, posts.post_modified_gmt,
-					posts.post_excerpt, posts.post_content, posts.post_parent, posts.menu_order, posts.guid,
-					users.user_login, usermeta_firstname.meta_value as author_firstname, usermeta_lastname.meta_value as author_lastname";
+					posts.post_excerpt, posts.post_content, posts.post_parent, posts.menu_order, posts.guid";
 	}
 
 	/**
@@ -169,15 +168,7 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 				JOIN {$wpdb->prefix}icl_translations translations
 						ON translations.element_type = 'post_{$this->current_request->post_type}'
 						AND translations.element_id = posts.ID
-						AND translations.language_code = '$current_language'" ) . "
-				JOIN $wpdb->users users
-						ON users.ID = posts.post_author
-				JOIN $wpdb->usermeta usermeta_firstname
-						ON usermeta_firstname.user_id = users.ID
-						AND usermeta_firstname.meta_key = 'first_name'
-				JOIN $wpdb->usermeta usermeta_lastname
-						ON usermeta_lastname.user_id = users.ID
-						AND usermeta_lastname.meta_key = 'last_name'";
+						AND translations.language_code = '$current_language'" );
 	}
 
 	/**

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v2/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v2/RestApi_ModifiedContent.php
@@ -255,14 +255,6 @@ abstract class RestApi_ModifiedContentV2 extends RestApi_ExtensionBase {
 		return $image_src[0];
 	}
 
-	protected function prepare_author($post) {
-		return [
-			'login' => $post->user_login,
-			'first_name' => $post->author_firstname,
-			'last_name' => $post->author_lastname
-		];
-	}
-
 	protected function prepare_url($post){
 		$page_id = $post->ID;
 		$date = $post->post_modified_gmt;

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v2/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v2/RestApi_ModifiedContent.php
@@ -150,8 +150,7 @@ abstract class RestApi_ModifiedContentV2 extends RestApi_ExtensionBase {
 	 */
 	protected function build_query_select() {
 		return "posts.ID, posts.post_title, posts.post_type, posts.post_status, posts.post_modified_gmt,
-					posts.post_excerpt, posts.post_content, posts.post_parent, posts.menu_order, posts.guid,
-					users.user_login, usermeta_firstname.meta_value as author_firstname, usermeta_lastname.meta_value as author_lastname";
+					posts.post_excerpt, posts.post_content, posts.post_parent, posts.menu_order, posts.guid";
 	}
 
 	/**
@@ -170,15 +169,7 @@ abstract class RestApi_ModifiedContentV2 extends RestApi_ExtensionBase {
 				JOIN {$wpdb->prefix}icl_translations translations
 						ON translations.element_type = 'post_{$this->current_request->post_type}'
 						AND translations.element_id = posts.ID
-						AND translations.language_code = '$current_language'" ) . "
-				JOIN $wpdb->users users
-						ON users.ID = posts.post_author
-				JOIN $wpdb->usermeta usermeta_firstname
-						ON usermeta_firstname.user_id = users.ID
-						AND usermeta_firstname.meta_key = 'first_name'
-				JOIN $wpdb->usermeta usermeta_lastname
-						ON usermeta_lastname.user_id = users.ID
-						AND usermeta_lastname.meta_key = 'last_name'";
+						AND translations.language_code = '$current_language'" );
 	}
 
 	/**


### PR DESCRIPTION
This removes user information from APIv0, v0 and v1 database queries. This information is not used in the API content and is therefore not required. The query results in content not being delivered if there are database inconsistencies with user IDs.

Fixes #806 