### PR TITLE
[api-events] include recurring events in APIv0-2 (fixes #852)

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v0/RestApi_ModifiedContent.php
@@ -79,12 +79,19 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 		$this->current_request->post_type = $type;
 		$this->current_request->rest_request = $request;
 
+		// array which does not contain published pages with an unpublished parent
+		$post_ids = $this->get_post_ids_recursive(0);
+
 		global $wpdb;
 		$querystr = $this->build_query_string();
-		$query_result = $wpdb->get_results($querystr, OBJECT);
+		$query_result = array_filter($wpdb->get_results($querystr, OBJECT), function ($post) use ($post_ids) {
+			// filter pages which have an unpublished parent
+			return in_array($post->ID, $post_ids);
+		});
 
 		if( $type == 'event' ) {
 			// fetch the initial of several recurring events (the initial events have a different post_type)
+			$this->current_request->post_type = 'event-recurring';
 			$querystr = $this->build_query_string();
 			$initial_events = $wpdb->get_results($querystr, OBJECT);
 			// fetch the recurring events for every initial event
@@ -97,11 +104,9 @@ abstract class RestApi_ModifiedContentV0 extends RestApi_ExtensionBase {
 			$query_result = array_merge($query_result, $recurring_events);
 		}
 
-		$post_ids = $this->get_post_ids_recursive(0);
-
 		$result = [];
 		foreach ($query_result as $post) {
-			if((isset($_GET['no_trash']) && $_GET['no_trash'] == '1' && $post->post_status == "trash") || !in_array($post->ID, $post_ids)) {
+			if(isset($_GET['no_trash']) && $_GET['no_trash'] == '1' && $post->post_status == "trash") {
 				continue;
 			}
 			$result[] = $this->prepare_item($post);


### PR DESCRIPTION
#### Short description of what this resolves:
- includes recurring events in api versions 0 - 2

#### Changes proposed in this pull request:
- make the sql query for recurring events working again
- perform filter for pages with unpublished parents before the recurring events are fetched (unfortunately, wpml hooks into the query, which caused problems with the filter and recurring events)

Fixes #852



### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
