### PR TITLE
Add City Aliases and coordinates

### DIFF
--- a/wp-content/plugins/ig-settings/classes/IntegreatSetting.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSetting.php
@@ -21,7 +21,7 @@ class IntegreatSetting {
 		$this->id = isset($setting->id) ? (int) $setting->id : null;
 		$this->name = isset($setting->name) && $setting->name !== '' ? $setting->name : null;
 		$this->alias = isset($setting->alias) && $setting->alias !== '' ? $setting->alias : null;
-		$this->type = isset($setting->type) && in_array($setting->type, ['string', 'bool']) ? $setting->type : null;
+		$this->type = isset($setting->type) && in_array($setting->type, ['string', 'bool', 'json']) ? $setting->type : null;
 	}
 
 	private function validate() {
@@ -49,10 +49,10 @@ class IntegreatSetting {
 			];
 			self::$current_error[] = 'alias';
 		}
-		if (!in_array($this->type, ['string', 'bool'])) {
+		if (!in_array($this->type, ['string', 'bool', 'json'])) {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
-				'message' => 'The given type "' . htmlspecialchars($this->type) . '" is not valid (must be "string" or "bool")'
+				'message' => 'The given type "' . htmlspecialchars($this->type) . '" is not valid (must be "string", "bool" or "json")'
 			];
 			self::$current_error[] = 'type';
 		}
@@ -223,6 +223,7 @@ class IntegreatSetting {
 					<select name="setting[type]">
 						<option value="string" ' . ($setting && $setting->type === 'string' ?  'selected' : '') . '>String</option>
 						<option value="bool" ' . ($setting && $setting->type === 'bool' ? 'selected' : '') . '>Boolean</option>
+						<option value="json" ' . ($setting && $setting->type === 'json' ? 'selected' : '') . '>JSON</option>
 					</select>
 				</div>
 				<br>

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
@@ -62,6 +62,14 @@ class IntegreatSettingConfig {
 			self::$current_error[] = $setting->alias;
 			return false;
 		}
+		if ($setting->type === 'json' && !json_decode($this->value)) {
+			IntegreatSettingsPlugin::$admin_notices[] = [
+				'type' => 'error',
+				'message' => 'The value "' . htmlspecialchars($this->value) . '" is no valid json'
+			];
+			self::$current_error[] = $setting->alias;
+			return false;
+		}
 		if ($setting->alias === 'plz') {
 			if ($this->value === '') {
 				/*
@@ -270,7 +278,7 @@ class IntegreatSettingConfig {
 					'setting_id' => $setting->id
 				]);
 			}
-			if ($setting->type === 'string') {
+			if ($setting->type === 'string' || $setting->type === 'json') {
 				$form .= '
 					<div>
 						<label for="' . $setting->id . '">' . htmlspecialchars($setting->name) . '</label>
@@ -316,7 +324,7 @@ class IntegreatSettingConfig {
 					} else {
 						$setting_config->value = '0';
 					}
-				} elseif ($setting->type === 'string') {
+				} elseif ($setting->type === 'string' || $setting->type === 'json') {
 					if (isset($_POST[$setting_config->setting_id])) {
 						$setting_config->value = str_replace('&quot;', '"', stripslashes($_POST[$setting_config->setting_id]));
 					} else {

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -253,7 +253,10 @@ class IntegreatSettingsPlugin {
 						alias = 'name_without_prefix' OR
 						alias = 'plz' OR
 						alias = 'events' OR
-						alias = 'push-notifications'
+						alias = 'push-notifications' OR
+						alias = 'city-aliases' OR
+						alias = 'longitude' OR
+						alias = 'latitude'
 				UNION SELECT 'extras', 'bool', (SELECT enabled FROM {$wpdb->prefix}ig_extras_config WHERE enabled LIMIT 1)", OBJECT_K));
 		}, 10, 0);
 		/*

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -240,7 +240,13 @@ class IntegreatSettingsPlugin {
 			// get all settings and union it with an additional extra setting which is true if at least one extra is enabled
 			return array_map(function ($setting) {
 				// cast setting value by its desired type
-				return ($setting->type === 'bool' ? (bool) $setting->value : ($setting->value === '' ? null : $setting->value));
+				if ($setting->type === 'bool') {
+					return (bool) $setting->value;
+				} elseif ($setting->type === 'json') {
+					return json_decode($setting->value);
+				} else {
+					return ($setting->value === '' ? null : $setting->value);
+				}
 			}, $wpdb->get_results(
 				"SELECT alias, type, value
 					FROM {$wpdb->base_prefix}ig_settings

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Sites.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Sites.php
@@ -29,6 +29,7 @@ class APIv3_Sites extends APIv3_Base_Abstract {
 		}
 		if (class_exists('IntegreatSettingsPlugin')) {
 			$result = array_merge($result, apply_filters('ig-settings-api', null));
+			$result['city-aliases'] = json_decode($result['city-aliases']);
 		}
 		restore_current_blog();
 		return $result;

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Sites.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Sites.php
@@ -29,7 +29,6 @@ class APIv3_Sites extends APIv3_Base_Abstract {
 		}
 		if (class_exists('IntegreatSettingsPlugin')) {
 			$result = array_merge($result, apply_filters('ig-settings-api', null));
-			$result['city-aliases'] = json_decode($result['city-aliases']);
 		}
 		restore_current_blog();
 		return $result;


### PR DESCRIPTION
* This adds the 'city-aliases', 'long' and 'lat' properties
  to the sites endpoint.
* 'long' and 'lat' contain the longitude and latitude of the
  approximate geographic center of the county/city.
* The 'city-aliases' can contain smaller municipalities within
  the county or city. For each alias, a longitude and latitude
  must be provided as well. To reduce load on the apps, the
  JSON is decoded to an object first, to integrate with the
  overall endpoint JSON.
* Fixes #865

The change is also added to the wiki page: https://github.com/Integreat/cms/wiki/REST-APIv3-Documentation#response

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [X] Check the commit's or even all commits' message styles matches your requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.
