### PR TITLE
Allow Verwalter to remove users

### DIFF
--- a/wp-content/plugins/ig-project-user-roles/plugin.php
+++ b/wp-content/plugins/ig-project-user-roles/plugin.php
@@ -29,6 +29,7 @@ register_activation_hook(__FILE__, function ($network_wide) {
 			'create_users' => true,
 			'edit_users' => true,
 			'delete_users' => true,
+			'remove_users' => true,
 			'promote_users' => true,
 			'list_users' => true,
 			/* Pages */


### PR DESCRIPTION
* In multisites, the role remove_users is required to
  remove a user from a blog. However, the user will not
  be removed from the database. This can only be done
  with the manage_network_users capability.
* Fixes #860

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [X] Check the commit's or even all commits' message styles matches your requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.
