### PR TITLE
Add blank target to IG wiki link

### DIFF
--- a/wp-content/plugins/ig-menu-help/plugin.php
+++ b/wp-content/plugins/ig-menu-help/plugin.php
@@ -17,5 +17,17 @@ function example_admin_menu() {
     load_plugin_textdomain( 'integreat-help', false, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
     global $submenu;
     $url = 'https://wiki.integreat-app.de/';
-    $submenu['tools.php'][] = array(__('Integreat Help'), 'edit_pages', $url);
+    $submenu['tools.php'][] = array('<div id="wikiblank">'.__('Integreat Wiki').'</div>', 'edit_pages', $url);
+}
+
+add_action( 'admin_footer', 'make_wiki_blank' );
+function make_wiki_blank()
+{
+    ?>
+    <script type="text/javascript">
+    jQuery(document).ready(function($) {
+        $('#wikiblank').parent().attr('target','_blank');
+    });
+    </script>
+    <?php
 }


### PR DESCRIPTION
* The Integreat Wiki link in the admin back end
  is opened in a blank window. The target attribute
  is not supported by the WP API and is therefore
  added by a jQuery script.
* Fixes #898