### PR TITLE
[ig-feedback] prevent jump to top of page when spoiler is folded out (Resolves #937)

### DIFF
--- a/wp-content/plugins/ig-feedback/script.js
+++ b/wp-content/plugins/ig-feedback/script.js
@@ -1,5 +1,6 @@
 jQuery(document).ready(function(){
-  jQuery('.ig-feedback-spoiler-show, .ig-feedback-spoiler-hide').click(function(){
+  jQuery('.ig-feedback-spoiler-show, .ig-feedback-spoiler-hide').click(function(event){
+      event.preventDefault();
       jQuery("[data-ig-feedback-comment-id='" + jQuery(this).data('ig-feedback-comment-id') + "']").toggle('fast');
   })
 });


### PR DESCRIPTION
Prevents the default link action (jump to top) when clicking on the comments spoiler.

Fixes: #937 

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
