### PR TITLE
Disable normal comment content

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -25,10 +25,6 @@ RewriteRule ^(.*)\.php$ - [L,END]
 # Redirect everything except of /wp-content/ and /wp-includes/ - both contain ressources like images
 RewriteRule ^(?!wp-(content|includes))(.*)$ https://integreat.app/$1$2 [R=301,L]
 
-<Files wp-includes/comment.php>
-	Order Allow,Deny
-	Deny from all
-</Files>
 <Files xmlrpc.php>
 	Order Allow,Deny
 	Deny from all


### PR DESCRIPTION
* Disallow posting any content via the normal Wordpress
  comment function to fix CVE-2019-9787.