### PR TITLE
Add all featured image sizes to events

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Events.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Events.php
@@ -155,6 +155,7 @@ class APIv3_Posts_Events extends APIv3_Posts_Abstract {
 		$prepared_event = parent::prepare($event);
 		$prepared_event['event'] = $this->prepare_event($event);
 		$prepared_event['location'] = $this->prepare_location($event);
+		$prepared_event['featured_image'] = $this->prepare_featured_image($event);
 		unset($prepared_event['parent']);
 		unset($prepared_event['order']);
 		unset($prepared_event['hash']);
@@ -171,6 +172,24 @@ class APIv3_Posts_Events extends APIv3_Posts_Abstract {
 		}
 		$prepared_event['hash'] = md5(json_encode($prepared_event));
 		return $prepared_event;
+	}
+
+	private function prepare_featured_image(WP_Post $event) {
+		if( has_post_thumbnail( $event->ID )) {
+			$image_data = array();
+			$image_data['description'] = the_post_thumbnail_caption( $event->ID );
+			$attachment_id = get_post_thumbnail_id( $event->ID );
+			$image_data['mimetype'] = get_post_mime_type( $attachment_id );
+			foreach ( array('thumbnail', 'medium', 'large', 'full') as $name ) {
+				$img_properties = wp_get_attachment_image_src( $attachment_id, $name );
+				$image_data[$name][0]['url'] = $img_properties[0];
+				$image_data[$name][0]['height'] = $img_properties[2];
+				$image_data[$name][0]['width'] = $img_properties[1];
+			}
+			return $image_data;
+		} else {
+			return null;
+		}
 	}
 
 	private function prepare_event(WP_Post $event) {


### PR DESCRIPTION
* For events, the web app uses the featured image with larger
  resolution than the 150px * 150px thumbnail. Therefore we
  need larger images. This commit adds the other preview sizes
  (medium, large) and also the full size image URL to the
  events APIv3 endpoint.
* Fixes #954 
* Adds the following object to each event in the APIv3, if an
  featured image exists. Otherwise, the `featured_image` is `null`.
```
    "featured_image": {
        "medium": String, // URL to 300 px image
        "large": String, // URL to 768px image
        "full": String, // URL to full sized image
    }
```
### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
