### PR TITLE
Add syslog logging on (failed) log in

### DIFF
--- a/wp-content/plugins/ig-customize-login-integreat/customize-login-integreat.php
+++ b/wp-content/plugins/ig-customize-login-integreat/customize-login-integreat.php
@@ -88,3 +88,16 @@ function replace_logo() {
 	</style>
 <?php }
 add_action( 'login_enqueue_scripts', 'replace_logo' );
+
+
+function ig_successful_login( $user_login, $user ) {
+	$url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+	syslog(LOG_NOTICE, "INTEGREAT CMS - LOGIN SUCCEEDED: $user_login via $url.");
+}
+add_action('wp_login', 'ig_successful_login', 10, 2);
+
+function ig_failed_login( $user_login ) {
+	$url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+	syslog(LOG_WARNING, "INTEGREAT CMS - LOGIN FAILED: $user_login from ".$_SERVER['REMOTE_ADDR']." via $url.");
+}
+add_action('wp_login_failed', 'ig_failed_login', 10, 1);


### PR DESCRIPTION
* We want to know which users logged in or failed
  to do so in our centralized logging server.
* Creates the following two syslog messages:
```
2019-03-22T16:31:11.906976+01:00 server9 ool www: INTEGREAT CMS: svenseeberg from 2003:e1:2719:a300:52d7:cc72:3fad:36d6 logged in via https://cms-test.integreat-app.de/wp-login.php.
2019-03-22T16:32:25.203822+01:00 server9 ool www: INTEGREAT CMS: svenorganisation from 2003:e1:2719:a300:52d7:cc72:3fad:36d6 failed to log in via https://cms-test.integreat-app.de/wp-login.php.
```

@dkehne is logging the IP addresses of our back end users compliant with our data protection rules?

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
