### PR TITLE
Add HTTP header to prevent tracking

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/helper/PiwikHelper.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/helper/PiwikHelper.php
@@ -5,7 +5,7 @@ function ig_api_page_tracking ( $call_name ) {
      * Contact Tracking server and save API hit
      */
     $token = get_blog_option(get_current_blog_id(), "wp-piwik_global-piwik_token");
-    if ( !$token ) {
+    if ( !$token or isset( $_SERVER['HTTP_X_INTEGREAT_DEVELOPMENT'] ) ) {
         $token = PIWIK_DEFAULT_AUTH_TOKEN;
         $idSite = PIWIK_DEFAULT_SITE_ID;
     } else {


### PR DESCRIPTION
* If the header 'X-Integreat-Development' is set,
  the API request will not be tracked for a single
  site but only in the general statistics.

Example usage:
```
curl --header "X-Integreat-Development: True" http://integreat/testumgebung/de/wp-json/extensions/v3/pages
```

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
