### PR TITLE
Allow leading slashes of relative permalinks for feedback api endpoint

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
@@ -53,7 +53,7 @@ abstract class APIv3_Feedback_Abstract extends APIv3_Base_Abstract {
 				return new WP_Error('rest_missing_param', 'Either the id or the permalink parameter is required', ['status' => 400]);
 			}
 			if ($id === null) {
-				$id = url_to_postid($permalink);
+				$id = url_to_postid(ltrim($permalink, '/'));
 			}
 			$language = apply_filters('wpml_post_language_details', null, $id)['language_code'];
 			$id = apply_filters('wpml_object_id', $id, 'any', true, 'de');

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
@@ -14,7 +14,7 @@ class APIv3_Feedback_Post extends APIv3_Feedback_Abstract {
 		];
 		$this->args['permalink'] = [
 			'validate_callback' => function($permalink) {
-				return $this->is_valid(url_to_postid($permalink));
+				return $this->is_valid(url_to_postid(ltrim($permalink, '/')));
 			}
 		];
 	}


### PR DESCRIPTION
Adds a `ltrim()` to the permalink because WPML does stupid things with translated permalinks and the function `url_to_postid()` does not work as expected on relative paths.
This way, either paths with leading slash or paths without them work.

I tested this on cms-test and it seems to work as expected.

Fixes #974
