### PR TITLE
Add float numbers to Integreat settings

### DIFF
--- a/wp-content/plugins/ig-settings/classes/IntegreatSetting.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSetting.php
@@ -21,7 +21,7 @@ class IntegreatSetting {
 		$this->id = isset($setting->id) ? (int) $setting->id : null;
 		$this->name = isset($setting->name) && $setting->name !== '' ? $setting->name : null;
 		$this->alias = isset($setting->alias) && $setting->alias !== '' ? $setting->alias : null;
-		$this->type = isset($setting->type) && in_array($setting->type, ['string', 'bool', 'json']) ? $setting->type : null;
+		$this->type = isset($setting->type) && in_array($setting->type, ['string', 'bool', 'json', 'float']) ? $setting->type : null;
 	}
 
 	private function validate() {
@@ -49,10 +49,10 @@ class IntegreatSetting {
 			];
 			self::$current_error[] = 'alias';
 		}
-		if (!in_array($this->type, ['string', 'bool', 'json'])) {
+		if (!in_array($this->type, ['string', 'bool', 'json', 'float'])) {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',
-				'message' => 'The given type "' . htmlspecialchars($this->type) . '" is not valid (must be "string", "bool" or "json")'
+				'message' => 'The given type "' . htmlspecialchars($this->type) . '" is not valid (must be "string", "bool", "json", or "float")'
 			];
 			self::$current_error[] = 'type';
 		}
@@ -224,6 +224,7 @@ class IntegreatSetting {
 						<option value="string" ' . ($setting && $setting->type === 'string' ?  'selected' : '') . '>String</option>
 						<option value="bool" ' . ($setting && $setting->type === 'bool' ? 'selected' : '') . '>Boolean</option>
 						<option value="json" ' . ($setting && $setting->type === 'json' ? 'selected' : '') . '>JSON</option>
+						<option value="float" ' . ($setting && $setting->type === 'float' ? 'selected' : '') . '>Float</option>
 					</select>
 				</div>
 				<br>

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
@@ -278,7 +278,7 @@ class IntegreatSettingConfig {
 					'setting_id' => $setting->id
 				]);
 			}
-			if ($setting->type === 'string' || $setting->type === 'json') {
+			if ($setting->type === 'string' || $setting->type === 'json' || $setting->type === 'float') {
 				$form .= '
 					<div>
 						<label for="' . $setting->id . '">' . htmlspecialchars($setting->name) . '</label>
@@ -335,6 +335,8 @@ class IntegreatSettingConfig {
 						$error_occurred = true;
 						continue;
 					}
+				} elseif ($setting->type === 'float') {
+					$setting_config->value = floatval($_POST[$setting_config->setting_id]);
 				}
 				if (!$setting_config->validate()) {
 					$error_occurred = true;

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -244,6 +244,8 @@ class IntegreatSettingsPlugin {
 					return (bool) $setting->value;
 				} elseif ($setting->type === 'json') {
 					return json_decode($setting->value);
+				} elseif ($setting->type === 'float') {
+					return floatval($setting->value);
 				} else {
 					return ($setting->value === '' ? null : $setting->value);
 				}


### PR DESCRIPTION
#### Short description of what this resolves:
- Adds the option to add numbers as an "Integreat Setting". This is required to output longitude and latitude as defined in our APIv3 documentation.

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
