### PR TITLE
 Change IG Settings empty JSON value

### DIFF
--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingConfig.php
@@ -62,6 +62,9 @@ class IntegreatSettingConfig {
 			self::$current_error[] = $setting->alias;
 			return false;
 		}
+		if ($setting->type === 'json' && $this->value === "") {
+			$this->value = "{}";
+		}
 		if ($setting->type === 'json' && !json_decode($this->value)) {
 			IntegreatSettingsPlugin::$admin_notices[] = [
 				'type' => 'error',

--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -264,7 +264,7 @@ class IntegreatSettingsPlugin {
 						alias = 'plz' OR
 						alias = 'events' OR
 						alias = 'push-notifications' OR
-						alias = 'city-aliases' OR
+						alias = 'aliases' OR
 						alias = 'longitude' OR
 						alias = 'latitude'
 				UNION SELECT 'extras', 'bool', (SELECT enabled FROM {$wpdb->prefix}ig_extras_config WHERE enabled LIMIT 1)", OBJECT_K));


### PR DESCRIPTION
If the user does not enter an empty JSON object, the plugin can assume that {} is okay.