### PR TITLE
Add Web/App User Agent to Matomo Tracking

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/helper/PiwikHelper.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/helper/PiwikHelper.php
@@ -24,7 +24,12 @@ function ig_api_page_tracking ( $call_name ) {
 
     // Privay overrides
     $piwikTracker->setBrowserLanguage('en');
-    $piwikTracker->setUserAgent('');
+    if ( strpos($_SERVER['HTTP_USER_AGENT'], 'okhttp') !== false or // Android app
+         strpos($_SERVER['HTTP_USER_AGENT'], 'Darwin') !== false ) { // iOS app
+        $piwikTracker->setUserAgent('App');
+    } else {
+        $piwikTracker->setUserAgent('Web');
+    }
     $piwikTracker->setResolution(1, 1);
     $piwikTracker->setIp(mt_rand(0,255).".".mt_rand(0,255).".0.0");
 


### PR DESCRIPTION
This change sends either "App" or "Web" as a user agent to the Matomo API. With that we can compare the usage of our Web App and Mobile App.

### Your checklist for this pull request
- [X] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [X] Check the commit's or even all commits' message styles matches your requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.
