### PR TITLE
Speed up API by not checking for empty content

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Abstract.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Posts_Abstract.php
@@ -68,7 +68,6 @@ abstract class APIv3_Posts_Abstract extends APIv3_Base_Abstract {
 		$GLOBALS['post'] = $post; // define global $post to prevent wordpress notices caused by events-manager
 		$post = apply_filters('wp_api_extensions_pre_post', $post);
 		setup_postdata($post);
-		$content = $this->prepare_content($post);
 		$output_post = [
 			'id' => $post->ID,
 			'url' => get_permalink($post),
@@ -76,7 +75,7 @@ abstract class APIv3_Posts_Abstract extends APIv3_Base_Abstract {
 			'title' => $post->post_title,
 			'modified_gmt' => $post->post_modified_gmt,
 			'excerpt' => $this->prepare_excerpt($post),
-			'content' => $content,
+			'content' => wpautop($post->post_content),
 			'parent' => [
 				'id' => $post->post_parent,
 				'url' => ($post->post_parent !== 0 ? get_permalink($post->post_parent) : null),
@@ -89,14 +88,6 @@ abstract class APIv3_Posts_Abstract extends APIv3_Base_Abstract {
 		$output_post = apply_filters('wp_api_extensions_output_post', $output_post);
 		$output_post['hash'] = md5(json_encode($output_post));
 		return $output_post;
-	}
-
-	private function prepare_content(WP_Post $post) {
-		$children = get_pages( [ 'child_of' => $post->ID ] );
-		if ($post->post_content === '' && count( $children ) === 0) {
-			$post->post_content = 'empty';
-		}
-		return wpautop($post->post_content);
 	}
 
 	private function prepare_excerpt(WP_Post $post) {


### PR DESCRIPTION
The function [`get_pages()`](https://developer.wordpress.org/reference/functions/get_pages/) seems to be very slow when executed multiple times within one request.
However, this function seems the go-to way to check whether an page has children [1], [2].
As a result, it does not seem justified to use this function just to determine if the content of a page is empty. We should rather drop the "empty"-string, because it is still clear that a page is empty by just seeing a blank page.


[1] https://wordpress.stackexchange.com/questions/73609/show-content-if-parent-page-has-children
[2] https://wordpress.stackexchange.com/questions/35724/function-to-return-true-if-current-page-has-child-pages?rq=1