### PR TITLE
Fix sql syntax error in ig-settings-api filter

### DIFF
--- a/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
+++ b/wp-content/plugins/ig-settings/classes/IntegreatSettingsPlugin.php
@@ -264,7 +264,7 @@ class IntegreatSettingsPlugin {
 						alias = 'plz' OR
 						alias = 'events' OR
 						alias = 'push-notifications' OR
-						alias = 'logo'
+						alias = 'logo' OR
 						alias = 'aliases' OR
 						alias = 'longitude' OR
 						alias = 'latitude'


### PR DESCRIPTION
#### Short description of what this resolves:
Resolves the database error when retrieving the sites api which leads to missing fields

#### Changes proposed in this pull request:
Fix sql syntax in ig-settings-api filter

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
