### PR TITLE
Add x-integreat-development to allowed CORS headers 

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,5 @@
 Header set Access-Control-Allow-Origin "*"
+Header add Access-Control-Allow-Headers "accept, authorization, content-type, origin, x-requested-with, x-integreat-development"
 
 RewriteEngine On
 RewriteBase /wordpress


### PR DESCRIPTION
#### Short description of what this resolves:
Add x-integreat-development to allowed CORS headers.

I'm not 100% sure which other headers wordpress needs and need to be whitelisted here.


Fixes #1040



### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
