### PR TITLE
Sanitize Feedback permalink, fixes WP-10

### DIFF
--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Abstract.php
@@ -25,6 +25,14 @@ abstract class APIv3_Feedback_Abstract extends APIv3_Base_Abstract {
 		];
 	}
 
+  public function sanitize_permalink($permalink) {
+		$host = "https://".$_SERVER['SERVER_NAME'];
+		if( substr($permalink, 0, strlen($host)) != $host ) {
+			$permalink = $host.$permalink;
+		}
+		return $permalink;
+  }
+
 	public function put_feedback(WP_REST_Request $request) {
 		$text = $request->get_param('comment');
 		$rating = $request->get_param('rating');
@@ -45,7 +53,7 @@ abstract class APIv3_Feedback_Abstract extends APIv3_Base_Abstract {
 		 */
 		if (static::TYPE === 'post') {
 			$id = $request->get_param('id');
-			$permalink = $request->get_param('permalink');
+			$permalink = $this::sanitize_permalink($request->get_param('permalink'));
 			/*
 			 * Throw an error if both id and permalink are missing
 			 */

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/v3/APIv3_Feedback_Post.php
@@ -14,7 +14,7 @@ class APIv3_Feedback_Post extends APIv3_Feedback_Abstract {
 		];
 		$this->args['permalink'] = [
 			'validate_callback' => function($permalink) {
-				return $this->is_valid(url_to_postid(ltrim($permalink, '/')));
+				return $this->is_valid(url_to_postid($this::sanitize_permalink($permalink)));
 			}
 		];
 	}


### PR DESCRIPTION
`url_to_postid()` breaks without host and procotol when the string contains Arabic or Farsi characters. Sanitizing the permalink URL by prepending the hostname, if required, fixes the issue.

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
