### PR TITLE
Add check for enabled FCM PN in admin Gui, fixes WP-12

### DIFF
--- a/wp-content/plugins/firebase-notifications/plugin.php
+++ b/wp-content/plugins/firebase-notifications/plugin.php
@@ -22,12 +22,14 @@ require_once __DIR__ . '/classes/database.php';
 function fb_pn_menu() {
   if (class_exists('IntegreatSettingsPlugin')) {
     $result = apply_filters('ig-settings-api', null);
-    var_dump($result);
+  } else { 
+    return;
   }
-
-	load_plugin_textdomain( 'firebase-notifications', false, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
-	add_menu_page( __('Push Notifications', 'firebase-notifications'), __('Push Notifications', 'firebase-notifications'), 'create_users', 'fb-pn', 'write_firebase_notification', 'dashicons-email-alt', $position = 99 );
-	add_submenu_page( 'fb-pn', __('Settings'), __('Settings'), 'manage_options', 'fb-pn-settings', 'firebase_notification_settings' );
+  if ( $result["push_notifications"] == true ) {
+    load_plugin_textdomain( 'firebase-notifications', false, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
+    add_menu_page( __('Push Notifications', 'firebase-notifications'), __('Push Notifications', 'firebase-notifications'), 'create_users', 'fb-pn', 'write_firebase_notification', 'dashicons-email-alt', $position = 99 );
+    add_submenu_page( 'fb-pn', __('Settings'), __('Settings'), 'manage_options', 'fb-pn-settings', 'firebase_notification_settings' );
+  }
 }
 add_action( 'admin_menu', 'fb_pn_menu' );
 

--- a/wp-content/plugins/firebase-notifications/plugin.php
+++ b/wp-content/plugins/firebase-notifications/plugin.php
@@ -20,6 +20,11 @@ require_once __DIR__ . '/classes/database.php';
  * Add menu entries to single blog
  */
 function fb_pn_menu() {
+  if (class_exists('IntegreatSettingsPlugin')) {
+    $result = apply_filters('ig-settings-api', null));
+    var_dump($result);
+  }
+
 	load_plugin_textdomain( 'firebase-notifications', false, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
 	add_menu_page( __('Push Notifications', 'firebase-notifications'), __('Push Notifications', 'firebase-notifications'), 'create_users', 'fb-pn', 'write_firebase_notification', 'dashicons-email-alt', $position = 99 );
 	add_submenu_page( 'fb-pn', __('Settings'), __('Settings'), 'manage_options', 'fb-pn-settings', 'firebase_notification_settings' );

--- a/wp-content/plugins/firebase-notifications/plugin.php
+++ b/wp-content/plugins/firebase-notifications/plugin.php
@@ -21,7 +21,7 @@ require_once __DIR__ . '/classes/database.php';
  */
 function fb_pn_menu() {
   if (class_exists('IntegreatSettingsPlugin')) {
-    $result = apply_filters('ig-settings-api', null));
+    $result = apply_filters('ig-settings-api', null);
     var_dump($result);
   }
 

--- a/wp-content/plugins/ig-wp-api-extensions/endpoints/liveinstances.txt
+++ b/wp-content/plugins/ig-wp-api-extensions/endpoints/liveinstances.txt
@@ -1,5 +1,0 @@
-2 // Augsburg
-8 // Duesseldorf
-11 // Bad Toelz
-15 // Main-Taunus-Kreis
-25 // Kiel


### PR DESCRIPTION
* Only show Push Notifications in admin menu if Integreat Push Notifications are renabled.
* Drop legacy list of enabled locations.

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
