### PR TITLE
Return 404 on sitemaps of hidden sites

### DIFF
--- a/wp-content/plugins/ig-sitemap/IntegreatSitemap.php
+++ b/wp-content/plugins/ig-sitemap/IntegreatSitemap.php
@@ -21,6 +21,10 @@ class IntegreatSitemap {
 	}
 
 	public function get_sitemap() {
+		$site = get_sites(['ID' => get_current_blog_id()])[0];
+		if (!$site->public || $site->spam || $site->deleted || $site->archived || $site->mature || apply_filters('ig-site-disabled', $site)) {
+		    return new WP_Error( 'rest_no_route', __( 'No route was found matching the URL and request method' ), array( 'status' => 404 ) );
+		}
 		header('Content-Type: application/xml');
 		global $wpdb;
 		if (self::XHTML_ENABLED) {


### PR DESCRIPTION
#### Short description of what this resolves:
- This is also part of the problem that hidden sites show up in the search index (WP-15)

#### Changes proposed in this pull request:
- return 404 when a crawler tries to find the "hidden" sitemap.xml files which are not included in the sitemap index

**Fixes**: WP-15



### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
  - [ ] Patch 0005 - Events Manager menu counter
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
