### PR TITLE
Allow translate attribute for span, fixes WP-19

### DIFF
--- a/wp-content/plugins/tinymce-no-translate/plugin.php
+++ b/wp-content/plugins/tinymce-no-translate/plugin.php
@@ -24,6 +24,14 @@ if ( is_admin() ) {
     } );
 }
 
+function allow_translate_attribute( $allowedposttags, $context ) {
+    if ( $context == 'post' ) {
+        $allowedposttags['span']['translate'] = true;
+    }
+    return $allowedposttags;
+}
+add_filter( 'wp_kses_allowed_html', 'allow_translate_attribute', 10, 2 );
+
 function add_tinymce_no_translate_plugin( $plugin_array ) {
     $plugin_array['no_translate_attribute'] = plugin_dir_url( __FILE__ ) . 'no-translate.js';
     return $plugin_array;


### PR DESCRIPTION
* Change tinymce-no-translate plugin to allow translate attributes in span tags.

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
  - [ ] Patch 0005 - Events Manager menu counter
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
