### PR TITLE
Fix WPML XLIFF import compatibility

### DIFF
--- a/wp-content/plugins/ig-attach-content/plugin.php
+++ b/wp-content/plugins/ig-attach-content/plugin.php
@@ -86,14 +86,16 @@ function ig_ac_save_meta_box( $post_id ) {
 	$key_position = 'ig-attach-content-position';
 	$key_blog = 'ig-attach-content-blog';
 	$key_page = 'ig-attach-content-page';
-	if ( -1 == $_POST[$key_blog] ) {
-		delete_post_meta( $post_id, $key_position);
-		delete_post_meta( $post_id, $key_blog);
-		delete_post_meta( $post_id, $key_page);
-	} else {
-		update_post_meta( $post_id, $key_position, $_POST[$key_position] );
-		update_post_meta( $post_id, $key_blog, $_POST[$key_blog] );
-		update_post_meta( $post_id, $key_page, $_POST[$key_page] );
+	if ( current_user_can( 'publish_pages' ) && $_POST["action"] == "editpost" ) {
+		if ( -1 == $_POST[$key_blog] && $_POST["action"] == "editpost" ) {
+			delete_post_meta( $post_id, $key_position);
+			delete_post_meta( $post_id, $key_blog);
+			delete_post_meta( $post_id, $key_page);
+		} else {
+			update_post_meta( $post_id, $key_position, $_POST[$key_position] );
+			update_post_meta( $post_id, $key_blog, $_POST[$key_blog] );
+			update_post_meta( $post_id, $key_page, $_POST[$key_page] );
+		}
 	}
 }
 add_action('save_post', 'ig_ac_save_meta_box');

--- a/wp-content/plugins/ig-push-content/plugin.php
+++ b/wp-content/plugins/ig-push-content/plugin.php
@@ -83,7 +83,7 @@ function ig_pc_save_meta_box( $post_id ) {
     $key_token = 'ig_push_content_token';
     $key_require_review = 'ig_push_content_review';
     $key_denied = 'ig_push_content_denied';
-    if ( current_user_can( 'publish_pages' ) ) {
+    if ( current_user_can( 'publish_pages' ) && $_POST["action"] == "editpost" ) {
         if ( Null == $_POST[$key_token] ) {
             delete_post_meta( $post_id, $key_token);
             delete_post_meta( $post_id, $key_require_review);


### PR DESCRIPTION
Only remove meta options for a page, if the POST contains the action=editpost variable.

#### Short description of what this resolves:
- XLIFF import removes Push Content API tokens and live content.

### Your checklist for this pull request
- [x] Check if patches need to be applied.
  - [ ] Patch 0001 - WPML
  - [ ] Patch 0002 - Broken Link Checker
  - [ ] Patch 0003 - CMS Tree View
  - [ ] Patch 0004 - Sitepress
  - [ ] Patch 0005 - Events Manager menu counter
  - [ ] Patch 0006 - RSS Feed (Add Date to Article)
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *develop*.
- [x] Check the commit's or even all commits' message styles matches your requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
