### PR TITLE
Export: map organizer to author role

### DIFF
--- a/export-database.php
+++ b/export-database.php
@@ -192,6 +192,8 @@
 				return 2; // -> Role EDITOR
 			} elseif ( array_key_exists( "event_planer", $roles )) {
 				return 3; // -> Role EVENT_MANAGER
+			} elseif ( array_key_exists( "organizer", $roles )) {
+				return 8; // -> Role AUTHOR
 			}
 			return null;
 		}


### PR DESCRIPTION
#### Short description of what this resolves:
- Based on https://github.com/digitalfabrik/integreat-cms/pull/1451 the WordPress `organizer` should be mapped to group/role `author` (pk=8).